### PR TITLE
log success result as JSON string

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -51,7 +51,7 @@ Lambda.prototype.run = function (program) {
 Lambda.prototype._runHandler = function (handler, event) {
   var context = {
     succeed: function (result) {
-      console.log('succeed: ' + result);
+      console.log('succeed: ' + JSON.stringify(result));
       process.exit(0);
     },
     fail: function (error) {


### PR DESCRIPTION
since lambda always has to return JSON, it is maybe a good idea to log the success result as JSON.