### PR TITLE
exclude .env file from being uploaded to amazon

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -97,7 +97,7 @@ Lambda.prototype._zipfileTmpPath = function (program) {
 };
 
 Lambda.prototype._rsync = function (program, codeDirectory, callback) {
-  exec('rsync -r --exclude=.git --exclude=*.log --exclude=node_modules . ' + codeDirectory, function (err) {
+  exec('rsync -r --exclude=.git --exclude=*.env --exclude=*.log --exclude=node_modules . ' + codeDirectory, function (err) {
     if (err) {
       throw err;
     }


### PR DESCRIPTION
I wanted to avoid having .env files uploaded to AWS so that my credentials wasn't exposed on the AWS platform if someone tried to download the function after having used 'node-lambda deploy'.
