### PR TITLE
Moving to system /tmp path breaks Windows deployment

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -13,6 +13,7 @@ var dotenv = require('dotenv');
 
 var Lambda = function () {
   this.version = packageJson.version;
+  this._codeDirectory = "dist/";
 
   return this;
 };
@@ -193,7 +194,7 @@ Lambda.prototype.deploy = function (program) {
 
   var _this = this;
   var regions = program.region.split(',');
-  var codeDirectory = "dist/";
+  var codeDirectory = this._codeDirectory;
 
   console.log('=> Moving files to temporary directory');
   // Move all files to tmp folder (except .git, .log, event.json and node_modules)

--- a/lib/main.js
+++ b/lib/main.js
@@ -156,11 +156,6 @@ Lambda.prototype._nativeZip = function (program, codeDirectory, callback) {
   });
 };
 
-Lambda.prototype._codeDirectory = function (program) {
-  var epoch_time = +new Date();
-
-  return os.tmpDir() + '/' + program.functionName + '-' + epoch_time;
-};
 
 Lambda.prototype._setEnvironmentVars = function (program, codeDirectory) {
   console.log('=> Setting "environment variables" for Lambda from %s', program.configFile);
@@ -198,7 +193,7 @@ Lambda.prototype.deploy = function (program) {
 
   var _this = this;
   var regions = program.region.split(',');
-  var codeDirectory = _this._codeDirectory(program);
+  var codeDirectory = "dist/";
 
   console.log('=> Moving files to temporary directory');
   // Move all files to tmp folder (except .git, .log, event.json and node_modules)

--- a/test/main.js
+++ b/test/main.js
@@ -25,7 +25,7 @@ var originalProgram = {
   region: 'us-east-1,us-west-2,eu-west-1'
 };
 
-var codeDirectory = lambda._codeDirectory(program);
+var codeDirectory = lambda._codeDirectory;
 
 describe('node-lambda', function () {
   beforeEach(function () {


### PR DESCRIPTION
Convention is to use ./dist anyway.
FYI It's nearly impossible to combine rsync and nodejs to work with C:/... or /c/..., it's much easiear to work with relative path. Everyone will probably understand that dist/ is supposed to go to .gitignore ;)

BTW to install rsync is also not simple, consider removing this hidden dependency, please.