### PR TITLE
Add option to create a sample file with a custom filename and fix the run command when running with a custom event file

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -17,8 +17,8 @@ var Lambda = function () {
   return this;
 };
 
-Lambda.prototype._createSampleFile = function (file) {
-  var exampleFile = process.cwd() + '/' + file;
+Lambda.prototype._createSampleFile = function (file, newFileName) {
+  var exampleFile = process.cwd() + '/' + (file || newFileName);
   var boilerplateFile = __dirname + '/' + file + '.example';
 
   if (!fs.existsSync(exampleFile)) {
@@ -36,7 +36,7 @@ Lambda.prototype.setup = function () {
 };
 
 Lambda.prototype.run = function (program) {
-  this._createSampleFile('event.json');
+  this._createSampleFile('event.json', program.eventFile);
 
   var splitHandler = program.handler.split('.');
   var filename = splitHandler[0] + '.js';


### PR DESCRIPTION
Hi,

I was running my lambda function with a different event file name (-j option) and I was seeing the event.json file always being created.

I've changed the behaviour of the `_createSampleFile` function and added an optional argument if we want to supply a different file name and kept the behaviour of the run command of creating a new sample file but now with the file name we supply on the event file option.

Tell me what you think.

Thanks,