### PR TITLE
Throw if a deployment command fails

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -51,7 +51,7 @@ Lambda.prototype.run = function (program) {
 Lambda.prototype._runHandler = function (handler, event) {
   var context = {
     succeed: function (result) {
-      console.log('succeed: ' + JSON.stringify(result));
+      console.log('succeed: ' + result);
       process.exit(0);
     },
     fail: function (error) {
@@ -205,13 +205,13 @@ Lambda.prototype.deploy = function (program) {
 
   _this._rsync(program, codeDirectory, function (err) {
     if (err) {
-      console.error(err);
+      throw err;
       return;
     }
     console.log('=> Running npm install --production');
     _this._npmInstall(program, codeDirectory, function (err) {
       if (err) {
-        console.error(err);
+        throw err;
         return;
       }
 
@@ -226,7 +226,7 @@ Lambda.prototype.deploy = function (program) {
 
       archive(program, codeDirectory, function (err, buffer) {
         if (err) {
-          console.error(err);
+          throw err;
           return;
         }
 
@@ -259,7 +259,7 @@ Lambda.prototype.deploy = function (program) {
 
         }, function (err, results) {
           if (err) {
-            console.error(err);
+            throw err;
           } else {
             console.log('=> Zip file(s) done uploading. Results follow: ');
             console.log(results);


### PR DESCRIPTION
CircleCi claims my deployments are a success even if they are made of fail.

Crudely, I've updated the deploy error handlers to `throw` instead of `console.log` the error.