### PR TITLE
Add -e to not escape \n when echo'ing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ node-lambda setup --help
 After running setup, it's a good idea to gitignore the generated `event.json` and `.env` files.
 
 ```
-echo ".env\ndeploy.env\nevent.json" >> .gitignore
+echo -e ".env\ndeploy.env\nevent.json" >> .gitignore
 ```
 
 #### run


### PR DESCRIPTION
- [ ] @motdotla 

Noticed a small bug in your docs. Adding `-e` will print `\n` as an actual new line.