### PR TITLE
exit with -1 on deploy error

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -206,13 +206,13 @@ Lambda.prototype.deploy = function (program) {
   _this._rsync(program, codeDirectory, function (err) {
     if (err) {
       console.error(err);
-      return;
+      process.exit(-1);
     }
     console.log('=> Running npm install --production');
     _this._npmInstall(program, codeDirectory, function (err) {
       if (err) {
         console.error(err);
-        return;
+        process.exit(-1);
       }
 
       // Add custom environment variables if program.configFile is defined
@@ -227,7 +227,7 @@ Lambda.prototype.deploy = function (program) {
       archive(program, codeDirectory, function (err, buffer) {
         if (err) {
           console.error(err);
-          return;
+          process.exit(-1);
         }
 
         console.log('=> Reading zip file to memory');
@@ -260,9 +260,11 @@ Lambda.prototype.deploy = function (program) {
         }, function (err, results) {
           if (err) {
             console.error(err);
+            process.exit(-1);
           } else {
             console.log('=> Zip file(s) done uploading. Results follow: ');
             console.log(results);
+            process.exit(0);
           }
         });
 


### PR DESCRIPTION
This enable us to detect successfulness of `node-lambda deploy` by exit code when invoked in a shell.