### PR TITLE
exclude build directory from zip

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -223,7 +223,7 @@ Lambda.prototype._zip = function (program, codeDirectory, callback) {
 
 Lambda.prototype._nativeZip = function (program, codeDirectory, callback) {
   var zipfile = this._zipfileTmpPath(program),
-    cmd = 'zip -r ' + zipfile + ' .';
+    cmd = 'zip -x \\*build\\* -r ' + zipfile + ' .';
 
   exec(cmd, {
     cwd: codeDirectory,


### PR DESCRIPTION
currently running package with no build directory argument creates build directory and zips in the application directory. When running subsequent builds the zip files include the previous build files which causes them to grow infinitely with each package run.

added -x \*build\* to command line for zip to exclude from packaging