### PR TITLE
Adding environment to env vars added in _setEnvironmentVars().

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -271,6 +271,8 @@ Lambda.prototype._setEnvironmentVars = function (program, codeDirectory) {
   var config = dotenv.parse(configValues);
   var contentStr = contents.toString();
 
+  prefix += 'process.env["environment"]=' + program.environment + ';\n';
+
   for (var k in config) {
     if (!config.hasOwnProperty(k)) {
       continue;

--- a/lib/main.js
+++ b/lib/main.js
@@ -271,7 +271,9 @@ Lambda.prototype._setEnvironmentVars = function (program, codeDirectory) {
   var config = dotenv.parse(configValues);
   var contentStr = contents.toString();
 
-  prefix += 'process.env["environment"]=' + program.environment + ';\n';
+  if(program.environment){
+      prefix += 'process.env["environment"]=' + program.environment + ';\n';
+  }
 
   for (var k in config) {
     if (!config.hasOwnProperty(k)) {


### PR DESCRIPTION
This update includes the 'environment' env variable with the deploy.env vars at the top of the handler when using --configFile flag with package or deploy command.

This allows for logic within the lambda function similar to:

```
if(process.env.environment === 'production'){
    // Production logic.
}else{
    // Non-production logic
}
```

or

```
var settings = {
    production: { /* Production settings */ },
    staging: { /* Staging settings */},
    dev: { /* Dev settings */ }
}
var config = settings[process.env.environment || 'dev' ];
```