### PR TITLE
Verify env vars before create sample files

### DIFF
--- a/bin/node-lambda
+++ b/bin/node-lambda
@@ -91,8 +91,10 @@ program
   .version(lambda.version)
   .command('setup')
   .description('Sets up the .env file.')
-  .action(function () {
-    lambda.setup();
+  .option('-j, --eventFile [' + EVENT_FILE + ']', 'Event JSON File', EVENT_FILE)
+  .option('-x, --contextFile [' + CONTEXT_FILE + ']', 'Context JSON File', CONTEXT_FILE)
+  .action(function (prg) {
+    lambda.setup(prg);
   });
 
 program.parse(process.argv);

--- a/lib/main.js
+++ b/lib/main.js
@@ -17,9 +17,9 @@ var Lambda = function () {
   return this;
 };
 
-Lambda.prototype._createSampleFile = function (file, newFileName) {
-  var exampleFile = process.cwd() + '/' + (file || newFileName);
-  var boilerplateFile = __dirname + '/' + file + '.example';
+Lambda.prototype._createSampleFile = function (file, boilerplateName) {
+  var exampleFile = process.cwd() + '/' + file;
+  var boilerplateFile = __dirname + '/' + (boilerplateName || file) + '.example';
 
   if (!fs.existsSync(exampleFile)) {
     fs.writeFileSync(exampleFile, fs.readFileSync(boilerplateFile));
@@ -27,17 +27,17 @@ Lambda.prototype._createSampleFile = function (file, newFileName) {
   }
 };
 
-Lambda.prototype.setup = function () {
+Lambda.prototype.setup = function (program) {
   console.log('Running setup.');
-  this._createSampleFile('.env');
-  this._createSampleFile('event.json');
-  this._createSampleFile('deploy.env');
-  this._createSampleFile('context.json');
-  console.log('Setup done. Edit the .env, deploy.env, context.json and event.json files as needed.');
+  this._createSampleFile('.env', '.env');
+  this._createSampleFile(program.eventFile, 'event.json');
+  this._createSampleFile('deploy.env', 'deploy.env');
+  this._createSampleFile(program.contextFile, 'context.json');
+  console.log('Setup done. Edit the .env, deploy.env, ' + program.contextFile + ' and ' + program.eventFile + ' files as needed.');
 };
 
 Lambda.prototype.run = function (program) {
-  this._createSampleFile('event.json', program.eventFile);
+  this._createSampleFile(program.eventFile, 'event.json');
   var splitHandler = program.handler.split('.');
   var filename = splitHandler[0] + '.js';
   var handlername = splitHandler[1];
@@ -322,7 +322,7 @@ Lambda.prototype._uploadNew = function(lambda, params, cb) {
 };
 
 Lambda.prototype._archive = function (program, archive_callback) {
-  this._createSampleFile('.env');
+  this._createSampleFile('.env', '.env');
 
   // Warn if not building on 64-bit linux
   var arch = process.platform + '.' + process.arch;


### PR DESCRIPTION

**This patch force node-lambda first look into env vars before create sampleFiles (context.json and event.json)**

Previously, every time **node-lambda run** was  executed, a **event.json** file was created even if  the **-j** parameter was informed, for example after execute:

`node-lambda run --handler test.handler -j test.json`

The event.json file would be unnecessarily created and the test.json file would not be created. The same logic occurs if the EVENT_FILE var was defined.

To correct it, this code force node-lambda first look into env vars before create sampleFiles (context.json and event.json).