### PR TITLE
Fixes #96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix `AWS_PUBLIS` typo [#102](https://github.com/motdotla/node-lambda/pull/102)
 ### Added
 - Allow checking on `process.env.environment` to context switch [#95](https://github.com/motdotla/node-lambda/pull/95)
+
+## [0.8.3] - 2016-05-12
+### Bugfixes
+- Added `EXCLUDE_GLOBS` to `package`, so your local ZIPs are the same as the ZIPs uploaded to AWS Lambda [#104](https://github.com/motdotla/node-lambda/pull/104)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ $ node-lambda package --help
     -n, --functionName [node-lambda]    Lambda FunctionName
     -e, --environment [staging]         Choose environment {development, staging, production}
     -f, --configFile []                 Path to file holding secret environment variables (e.g. "deploy.env")
+    -x, --excludeGlobs []               Add a comma separated list of file(type)s to ignore (e.g. "*.json")
 ```
 
 #### deploy
@@ -116,9 +117,10 @@ $ node-lambda deploy --help
     -u, --runtime [nodejs4.3]         Lambda Runtime {nodejs4.3, nodejs} - "nodejs4.3" is the current standard, "nodejs" is v0.10.36 
     -p, --publish [false]             This boolean parameter can be used to request AWS Lambda to create the Lambda function and publish a version as an atomic operation
     -v, --version [custom-version]    Lambda Version
-    -f, --configFile []               Path to file holding secret environment variables (e.g. "deploy.env")`
+    -f, --configFile []               Path to file holding secret environment variables (e.g. "deploy.env")
     -b, --vpcSubnets []               VPC Subnet ID(s, comma separated list) for your Lambda Function, when using this, the below param is also required
     -g, --vpcSecurityGroups []        VPC Security Group ID(s, comma separated list) for your Lambda Function, when using this, the above param is also required
+    -x, --excludeGlobs []             Add a comma separated list of file(type)s to ignore (e.g. "*.json")
 ```
 
 ## Custom Environment Variables

--- a/bin/node-lambda
+++ b/bin/node-lambda
@@ -69,6 +69,8 @@ program
   .option('--handler [' + AWS_HANDLER + ']', 'Lambda Handler {index.handler}', AWS_HANDLER)
   .option('-e, --environment [' + AWS_ENVIRONMENT + ']', 'Choose environment {dev, staging, production}',
     AWS_ENVIRONMENT)
+  .option('-x, --excludeGlobs [' + EXCLUDE_GLOBS + ']',
+    'Space-separated glob pattern(s) for additional exclude files (e.g. "event.json dotenv.sample")', EXCLUDE_GLOBS)
   .option('-f, --configFile [' + CONFIG_FILE + ']',
     'Path to file holding secret environment variables (e.g. "deploy.env")', CONFIG_FILE)
   .action(function (prg) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lambda",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Command line tool for locally running and remotely deploying your node.js applications to Amazon Lambda.",
   "main": "lib/main.js",
   "directories": {

--- a/test/main.js
+++ b/test/main.js
@@ -34,7 +34,7 @@ describe('node-lambda', function () {
   });
 
   it('version should be set', function () {
-    assert.equal(lambda.version, '0.8.2');
+    assert.equal(lambda.version, '0.8.3');
   });
 
   describe('_params', function () {


### PR DESCRIPTION
Even though `package` and `deploy` called the same `rsync` function (which handled the excludes) the `EXCLUDE_GLOBS` was not passed on from `node-lambda` itself (simply not added yet.)

Fixes https://github.com/motdotla/node-lambda/issues/96