### PR TITLE
fix unquoted environment string

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -272,7 +272,7 @@ Lambda.prototype._setEnvironmentVars = function (program, codeDirectory) {
   var contentStr = contents.toString();
 
   if(program.environment){
-      prefix += 'process.env["environment"]=' + program.environment + ';\n';
+      prefix += 'process.env["environment"]=' + JSON.stringify(program.environment) + ';\n';
   }
 
   for (var k in config) {


### PR DESCRIPTION
This recent change let to the environment string being prepended into the handler script without quote marks. This caused the lambda function to stop working as expected.