### PR TITLE
Silent output of npm install

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -163,7 +163,7 @@ Lambda.prototype._rsync = function (program, codeDirectory, callback) {
 };
 
 Lambda.prototype._npmInstall = function (program, codeDirectory, callback) {
-  exec('npm install --production --prefix ' + codeDirectory, function (err) {
+  exec('npm -s install --production --prefix ' + codeDirectory, function (err) {
     if (err) {
       return callback(err);
     }


### PR DESCRIPTION
When trying to deploy my lambda I get the following output:

```
=> Moving files to temporary directory
=> Running npm install --production
/usr/src/app/node_modules/node-lambda/lib/main.js:421
      throw err;
      ^

Error: stderr maxBuffer exceeded
    at Socket.<anonymous> (child_process.js:285:14)
    at emitOne (events.js:77:13)
    at Socket.emit (events.js:169:7)
    at readableAddChunk (_stream_readable.js:153:18)
    at Socket.Readable.push (_stream_readable.js:111:10)
    at Pipe.onread (net.js:531:20)
```

This seems to occur for particularly verbose output. Adding `-s` to `npm install` seems to do the trick.