### PR TITLE
Copy the symlink content

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -154,7 +154,7 @@ Lambda.prototype._rsync = function (program, src, dest, callback) {
 
     // we need the extra / after src to make sure we are copying the content
     // of the directory, not the directory itself.
-    exec('rsync -r ' + excludeArgs + ' ' + src.trim() + '/ ' + dest, function (err) {
+    exec('rsync -rL ' + excludeArgs + ' ' + src.trim() + '/ ' + dest, function (err) {
       if (err) {
         return callback(err);
       }


### PR DESCRIPTION
Hi,

Is is possible to add the `-L` option when doing the `rsync`?

I have added and everything is working. I was in need to use added because I am having the following structure in a project:
```
/lambda-function-A
/lambda-function-B
/lambda-function-C
/common-library
```

being each lambda-function a js module and each having a symlink to the `common-library`.

I tried different solutions like using `npm-link` or add to the `package.json` the `file://` option but they don't work because they are one directory above.

The solution I found that it works is adding a `symlink` and copying it contents when executing `rsync`.

Thanks!