### PR TITLE
Set environment variables before requiring module

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -42,14 +42,14 @@ Lambda.prototype.run = function (program) {
   var filename = splitHandler[0] + '.js';
   var handlername = splitHandler[1];
 
-  var handler = require(process.cwd() + '/' + filename)[handlername];
-  var event = require(process.cwd() + '/' + program.eventFile);
-  var context = require(process.cwd() + '/' + program.contextFile);
-
   // Set custom environment variables if program.configFile is defined
   if (program.configFile) {
     this._setRunTimeEnvironmentVars(program);
   }
+
+  var handler = require(process.cwd() + '/' + filename)[handlername];
+  var event = require(process.cwd() + '/' + program.eventFile);
+  var context = require(process.cwd() + '/' + program.contextFile);
 
   this._runHandler(handler, event, program.runtime, context);
 };


### PR DESCRIPTION
In Lambda, the process.env variables are set at the very beginning before anything is run.

`run` needs to set `process.env` before it requires the handler, otherwise the handler's script file or dependencies cannot do initialization using the env variables outside of the handler itself.