### PR TITLE
Fix Publish parameter not working when updating existing function

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -322,7 +322,7 @@ Lambda.prototype._uploadExisting = function(lambda, params, cb) {
   return lambda.updateFunctionCode({
     'FunctionName': params.FunctionName,
     'ZipFile': params.Code.ZipFile,
-    'Publish': params.publish
+    'Publish': params.Publish
   }, function(err, data) {
     if(err) {
       return cb(err, data);


### PR DESCRIPTION
Fixed a typo in the parameters that was preventing the `Publish` functionality to work when updating an existing Lambda function.