### PR TITLE
Never exclude package.json, even when specified in excludeGlobs.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -160,9 +160,12 @@ Lambda.prototype._rsync = function (program, src, dest, excludeNodeModules, call
       return callback(err);
     }
 
+    // include package.json unless prebuiltDirectory is set
+    var includeArgs = program.prebuiltDirectory ? '' : '--include package.json ';
+
     // we need the extra / after src to make sure we are copying the content
     // of the directory, not the directory itself.
-    exec('rsync -rL --include package.json ' + excludeArgs + ' ' + src.trim() + '/ ' + dest, function (err) {
+    exec('rsync -rL ' + includeArgs + excludeArgs + ' ' + src.trim() + '/ ' + dest, function (err) {
       if (err) {
         return callback(err);
       }

--- a/lib/main.js
+++ b/lib/main.js
@@ -162,7 +162,7 @@ Lambda.prototype._rsync = function (program, src, dest, excludeNodeModules, call
 
     // we need the extra / after src to make sure we are copying the content
     // of the directory, not the directory itself.
-    exec('rsync -rL ' + excludeArgs + ' ' + src.trim() + '/ ' + dest, function (err) {
+    exec('rsync -rL --include package.json ' + excludeArgs + ' ' + src.trim() + '/ ' + dest, function (err) {
       if (err) {
         return callback(err);
       }

--- a/test/main.js
+++ b/test/main.js
@@ -131,6 +131,17 @@ describe('node-lambda', function () {
           done();
         });
       });
+
+      it('rsync should not exclude package.json, even when excluded by excludeGlobs', function (done) {
+        program.excludeGlobs="*.json"
+        lambda._rsync(program, '.', codeDirectory, true, function(err, result) {
+          var contents = fs.readdirSync(codeDirectory);
+          result = _.includes(contents, 'package.json');
+          assert.equal(result, true);
+
+          done();
+        });
+      });
     });
   });
 

--- a/test/main.js
+++ b/test/main.js
@@ -142,6 +142,28 @@ describe('node-lambda', function () {
           done();
         });
       });
+
+      it('rsync should not include package.json when --prebuiltDirectory is set', function (done) {
+        var path = '.build_' + Date.now();
+        after(function() {
+          rimraf.sync(path, fs);
+        });
+
+        fs.mkdirSync(path);
+        fs.writeFileSync(path + '/testa');
+        fs.writeFileSync(path + '/package.json');
+
+        program.excludeGlobs = "*.json"
+        program.prebuiltDirectory = path;
+        lambda._rsync(program, path, codeDirectory, true, function(err, result) {
+          var contents = fs.readdirSync(codeDirectory);
+          result = !_.includes(contents, 'package.json') &&
+                    _.includes(contents, 'testa');
+          assert.equal(result, true);
+
+          done();
+        });
+      });
     });
   });
 


### PR DESCRIPTION
If someone specifies `*.json` or even `package.json` via the `excludeGlobs`, the `npm install` step in the tmp folder will fail due to `ENOPACKAGEJSON`. This PR modifies the `rsync` command to always include the `package.json`, similar to how certain files are always excluded.