### PR TITLE
Changed mkdir to mkdirs (mkdir -p)

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -259,7 +259,7 @@ Lambda.prototype._cleanDirectory = function (codeDirectory, callback) {
       throw err;
     }
 
-    fs.mkdir(codeDirectory, function (err) {
+    fs.mkdirs(codeDirectory, function (err) {
       if (err) {
         throw err;
       }
@@ -438,7 +438,7 @@ Lambda.prototype.package = function (program) {
     } catch(err) {
       if (err.code === 'ENOENT') {
         console.log('=> Creating package directory');
-        fs.mkdirSync(program.packageDirectory);
+        fs.mkdirsSync(program.packageDirectory);
       } else {
         throw err;
       }


### PR DESCRIPTION
#157 seems to be caused by having namespaced packages.

If the package is "@namespace/package" or in fact anything containing a `/` it fails. Changing calls to `fs-extra.mkdir` to `fs-extra.mkdirs` seems to fix this.