### PR TITLE
Make default excludes apply to root only

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -146,7 +146,7 @@ Lambda.prototype._params = function (program, buffer) {
       Variables: config
     }
   }
-  
+
   return params;
 };
 
@@ -162,14 +162,14 @@ Lambda.prototype._zipfileTmpPath = function (program) {
 };
 
 Lambda.prototype._rsync = function (program, src, dest, excludeNodeModules, callback) {
-  var excludes = ['.git*', '*.swp', '.editorconfig', 'deploy.env', '*.log', 'build/'],
+  var excludes = ['.git*', '*.swp', '.editorconfig', 'deploy.env', '*.log', '/build/'],
       excludeGlobs = [];
   if (program.excludeGlobs) {
     excludeGlobs = program.excludeGlobs.split(' ');
   }
   var excludeArgs = excludeGlobs
     .concat(excludes)
-    .concat(excludeNodeModules ? ['node_modules'] : [])
+    .concat(excludeNodeModules ? ['/node_modules'] : [])
     .map(function (exclude) {
       return '--exclude=' + exclude;
     }).join(' ');

--- a/lib/main.js
+++ b/lib/main.js
@@ -96,7 +96,7 @@ Lambda.prototype._runHandler = function (handler, event, program, context) {
     return timeout - (currentTime - startTime);
   };
 
-  switch(runtime) {
+  switch(program.runtime) {
     case "nodejs":
       handler(event, context);
     break;


### PR DESCRIPTION
I had a use case recently where I needed to package up some prebuilt binaries / modules, and the default excludes given to rsync were causing some portions of that to be left out.

Turns out, rsync treats exclude paths as relative regardless of whether they contain a preceding slash or not, so placing a slash at the beginning of the path will only exclude those items if they are present in the root of the source directory.

Thanks for the great library!

PS. Also included a fix for a ReferenceError I was getting with the `run` command.