### PR TITLE
Docker support

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -10,6 +10,8 @@ var async = require('async');
 var zip = new require('node-zip')();
 var dotenv = require('dotenv');
 
+var maxBufferSize = 50 * 1024 * 1024;
+
 var Lambda = function () {
   this.version = packageJson.version;
 
@@ -146,7 +148,7 @@ Lambda.prototype._params = function (program, buffer) {
       Variables: config
     }
   }
-  
+
   return params;
 };
 
@@ -184,7 +186,10 @@ Lambda.prototype._rsync = function (program, src, dest, excludeNodeModules, call
 
     // we need the extra / after src to make sure we are copying the content
     // of the directory, not the directory itself.
-    exec('rsync -rL ' + includeArgs + excludeArgs + ' ' + src.trim() + '/ ' + dest, function (err) {
+    exec('rsync -rL ' + includeArgs + excludeArgs + ' ' + src.trim() + '/ ' + dest, {
+      maxBuffer: maxBufferSize,
+      env: process.env
+    }, function (err) {
       if (err) {
         return callback(err);
       }
@@ -195,7 +200,10 @@ Lambda.prototype._rsync = function (program, src, dest, excludeNodeModules, call
 };
 
 Lambda.prototype._npmInstall = function (program, codeDirectory, callback) {
-  exec('npm -s install --production --prefix ' + codeDirectory, function (err) {
+  exec('npm -s install --production --prefix ' + codeDirectory, {
+    maxBuffer: maxBufferSize,
+    env: process.env
+  }, function (err) {
     if (err) {
       return callback(err);
     }
@@ -213,7 +221,9 @@ Lambda.prototype._postInstallScript = function (program, codeDirectory, callback
   fs.exists(filePath, function (exists) {
     if (exists) {
       console.log('=> Running post install script ' + script_filename);
-      exec(cmd, { cwd: codeDirectory, maxBuffer: 50 * 1024 * 1024 }, function (error, stdout, stderr) {
+      exec(cmd, { env: process.env, cwd: codeDirectory, maxBuffer: maxBufferSize },
+        function (error, stdout, stderr) {
+
         if (error) {
           callback(error + " stdout: " + stdout + " stderr: " + stderr);
         } else {
@@ -255,8 +265,9 @@ Lambda.prototype._nativeZip = function (program, codeDirectory, callback) {
     cmd = 'zip -r ' + zipfile + ' .';
 
   exec(cmd, {
+    env: process.env,
     cwd: codeDirectory,
-    maxBuffer: 50 * 1024 * 1024
+    maxBuffer: maxBufferSize
   }, function (err) {
     if (err !== null) {
       return callback(err, null);


### PR DESCRIPTION
I ran into a few issues while trying to run node-lambda within a Ubuntu Docker container. 

**Error: stdout maxBuffer exceeded.**
The child_process call to rsync is causing a maxBuffer exceeded error when copying files from a mounted volume to local Docker space. This PR adds the maxBuffer option to several exec() calls.

The correct fix would probably be to implement spawn('', { stdio: 'ignore' }) instead of exec() since the commands stdout is being ignore anyway.


**Command not found**
When running through Docker, the env variables are not being passed to exec(). This prevents 'rsync' from working since the $PATH variable is empty. I've updated the exec() calls include process.env variables.