### PR TITLE
bump to 0.8.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,3 +98,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Features
 - Added getRemainingTimeInMillis() to the context when running locally. [#179](https://github.com/motdotla/node-lambda/pull/179)
 - Adding support for lambda environment variables [#181](https://github.com/motdotla/node-lambda/pull/181)
+
+## [0.8.13] - 2017-02-12
+### Bugfixes
+- Fixed wrong runtime call [#188](https://github.com/motdotla/node-lambda/pull/188)
+- Docker support [#186](https://github.com/motdotla/node-lambda/pull/186)
+- Make default excludes apply to root only [#185](https://github.com/motdotla/node-lambda/pull/185)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lambda",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "Command line tool for locally running and remotely deploying your node.js applications to Amazon Lambda.",
   "main": "lib/main.js",
   "directories": {

--- a/test/main.js
+++ b/test/main.js
@@ -36,7 +36,7 @@ describe('node-lambda', function () {
   });
 
   it('version should be set', function () {
-    assert.equal(lambda.version, '0.8.12');
+    assert.equal(lambda.version, '0.8.13');
   });
 
   describe('_params', function () {


### PR DESCRIPTION
## [0.8.13] - 2017-02-12
### Bugfixes
- Fixed wrong runtime call [#188](https://github.com/motdotla/node-lambda/pull/188)
- Docker support [#186](https://github.com/motdotla/node-lambda/pull/186)
- Make default excludes apply to root only [#185](https://github.com/motdotla/node-lambda/pull/185)