### PR TITLE
Fix unit test failure at travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 
 node_js:
-  - 0.10
-  - 0.12
   - 4
   - 5
   - 6


### PR DESCRIPTION
I got the following error
'Node.js version v0.10.48 does not meet requirement for yarn. Please use
Node.js 4 or later.'