### PR TITLE
Add 'Runtime' to the params of lambda.updateFunctionConfiguration

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -330,6 +330,7 @@ Lambda.prototype._uploadExisting = function (lambda, params, cb) {
       'MemorySize': params.MemorySize,
       'Role': params.Role,
       'Timeout': params.Timeout,
+      'Runtime': params.Runtime,
       'VpcConfig': params.VpcConfig,
       'Environment': params.Environment
     }, function (err, data) {


### PR DESCRIPTION
I thought that it was more convenient to update Runtime so I fixed it.
I'm sorry if I concluded that it is better not to specify it in the discussion so far.