### PR TITLE
bump to 0.8.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,3 +104,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed wrong runtime call [#188](https://github.com/motdotla/node-lambda/pull/188)
 - Docker support [#186](https://github.com/motdotla/node-lambda/pull/186)
 - Make default excludes apply to root only [#185](https://github.com/motdotla/node-lambda/pull/185)
+
+
+## [0.8.14] - 2017-03-27
+### Features
+- Event source mapping support [#189](https://github.com/motdotla/node-lambda/pull/189)
+- Fix version of Node.js supported by AWS Lambda [#197](https://github.com/motdotla/node-lambda/pull/197)
+- How about it if you have the option to specify the zip file? [#199](https://github.com/motdotla/node-lambda/pull/199)
+- Add 'Runtime' to the params of lambda.updateFunctionConfiguration [#200](https://github.com/motdotla/node-lambda/pull/200)
+
+### Bugfixes
+- Fix unit test failure at travis [#198](https://github.com/motdotla/node-lambda/pull/198)

--- a/event_sources.json
+++ b/event_sources.json
@@ -1,0 +1,8 @@
+[
+    {
+        "EventSourceArn": "your event source arn",
+        "StartingPosition": "LATEST",
+        "BatchSize": 100,
+        "Enabled": true
+    }
+]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lambda",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "description": "Command line tool for locally running and remotely deploying your node.js applications to Amazon Lambda.",
   "main": "lib/main.js",
   "directories": {

--- a/test/main.js
+++ b/test/main.js
@@ -36,7 +36,7 @@ describe('node-lambda', function () {
   });
 
   it('version should be set', function () {
-    assert.equal(lambda.version, '0.8.13');
+    assert.equal(lambda.version, '0.8.14');
   });
 
   describe('_params', function () {


### PR DESCRIPTION
## [0.8.14] - 2017-03-27
### Features
- Event source mapping support [#189](https://github.com/motdotla/node-lambda/pull/189)
- Fix version of Node.js supported by AWS Lambda [#197](https://github.com/motdotla/node-lambda/pull/197)
- How about it if you have the option to specify the zip file? [#199](https://github.com/motdotla/node-lambda/pull/199)
- Add 'Runtime' to the params of lambda.updateFunctionConfiguration [#200](https://github.com/motdotla/node-lambda/pull/200)

### Bugfixes
- Fix unit test failure at travis [#198](https://github.com/motdotla/node-lambda/pull/198)