### PR TITLE
Fix default value of EVENT_SOURCE_FILE set ''

### DIFF
--- a/bin/node-lambda
+++ b/bin/node-lambda
@@ -12,7 +12,7 @@ dotenv.load();
 
 var AWS_ENVIRONMENT = process.env.AWS_ENVIRONMENT || '';
 var CONFIG_FILE = process.env.CONFIG_FILE || '';
-var EVENT_SOURCE_FILE = process.env.EVENT_SOURCE_FILE || 'event_sources.json';
+var EVENT_SOURCE_FILE = process.env.EVENT_SOURCE_FILE || '';
 var EXCLUDE_GLOBS = process.env.EXCLUDE_GLOBS || '';
 var AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
 var AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY;


### PR DESCRIPTION
The reason is as follows
* Upgrading to 0.8.14 will cause event_sources.json to fall with missing errors
    * Although it solves with `node-lambda setup`, it will always result in an error unless you execute that command
* ScheduleEvents can not be set in createEventSourceMapping used by _updateEventSources
    * http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Lambda.html#createEventSourceMapping-property