### PR TITLE
bump to 0.8.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,3 +115,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Bugfixes
 - Fix unit test failure at travis [#198](https://github.com/motdotla/node-lambda/pull/198)
+
+## [0.8.15] - 2017-03-28
+### Features
+- Added DeadLetterConfig parameter [#206](https://github.com/motdotla/node-lambda/pull/206)
+
+### Bugfixes
+- Fix default value of EVENT_SOURCE_FILE set '' [#205](https://github.com/motdotla/node-lambda/pull/205)
+- Removed event_sources.json [#204](https://github.com/motdotla/node-lambda/pull/204)
+- Add -S, --eventSourceFile option. [#203](https://github.com/motdotla/node-lambda/pull/203)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lambda",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "Command line tool for locally running and remotely deploying your node.js applications to Amazon Lambda.",
   "main": "lib/main.js",
   "directories": {

--- a/test/main.js
+++ b/test/main.js
@@ -37,7 +37,7 @@ describe('node-lambda', function () {
   });
 
   it('version should be set', function () {
-    assert.equal(lambda.version, '0.8.14');
+    assert.equal(lambda.version, '0.8.15');
   });
 
   describe('_params', function () {


### PR DESCRIPTION
## [0.8.15] - 2017-03-28
### Features
- Added DeadLetterConfig parameter [#206](https://github.com/motdotla/node-lambda/pull/206)

### Bugfixes
- Fix default value of EVENT_SOURCE_FILE set '' [#205](https://github.com/motdotla/node-lambda/pull/205)
- Removed event_sources.json [#204](https://github.com/motdotla/node-lambda/pull/204)
- Add -S, --eventSourceFile option. [#203](https://github.com/motdotla/node-lambda/pull/203)