### PR TITLE
Fix default value of params.Environment.Variables is null

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -111,7 +111,7 @@ Lambda.prototype._params = function (program, buffer) {
       SecurityGroupIds: []
     },
     Environment: {
-      Variables: {}
+      Variables: null
     },
     DeadLetterConfig: {
       TargetArn: null
@@ -129,6 +129,7 @@ Lambda.prototype._params = function (program, buffer) {
   if (program.configFile) {
     var configValues = fs.readFileSync(program.configFile);
     var config = dotenv.parse(configValues);
+    // If `configFile` is an empty file, `config` value will be `{}`
     params.Environment = {
       Variables: config
     }

--- a/test/main.js
+++ b/test/main.js
@@ -95,10 +95,12 @@ describe('node-lambda', function () {
       beforeEach(function () {
         // Prep...
         fs.writeFileSync('tmp.env', 'FOO=bar\nBAZ=bing\n');
+        fs.writeFileSync('empty.env', '');
       });
 
       afterEach(function () {
         fs.unlinkSync('tmp.env');
+        fs.unlinkSync('empty.env');
       });
 
       it('adds variables when configFile param is set', function () {
@@ -108,9 +110,15 @@ describe('node-lambda', function () {
         assert.equal(params.Environment.Variables['BAZ'], "bing");
       });
 
-      it('does not add when configFile param is not set', function () {
+      it('when configFile param is set but it is an empty file', function () {
+        program.configFile = 'empty.env';
         var params = lambda._params(program);
         assert.equal(Object.keys(params.Environment.Variables).length, 0);
+      });
+
+      it('does not add when configFile param is not set', function () {
+        var params = lambda._params(program);
+        assert.isNull(params.Environment.Variables);
       });
     });
   });


### PR DESCRIPTION
If `{}` is set, it will be set as empty.
If you want to empty, you can specify an empty file in `configFile`