### PR TITLE
Fix to use authenticated `aws` object in main.js

### DIFF
--- a/lib/schedule_events.js
+++ b/lib/schedule_events.js
@@ -1,14 +1,16 @@
 'use strict';
 
-const aws = require('aws-sdk');
-const lambda = new aws.Lambda({
-  apiVersion: '2015-03-31'
-});
-const cloudwatchevents = new aws.CloudWatchEvents({
-  apiVersion: '2015-10-07'
-});
+const ScheduleEvents = function(aws) {
+  // Authenticated `aws` object in `lib/main.js`
+  this.lambda = new aws.Lambda({
+    apiVersion: '2015-03-31'
+  });
+  this.cloudwatchevents = new aws.CloudWatchEvents({
+    apiVersion: '2015-10-07'
+  });
+};
 
-const ScheduleEvents = {
+ScheduleEvents.prototype = {
   _ruleDescription: (params) => {
     return `${params.ScheduleName} - ${params.ScheduleExpression}`;
   },
@@ -17,20 +19,21 @@ const ScheduleEvents = {
     return params.FunctionArnPrefix + params.FunctionName;
   },
 
-  _putRulePrams: (params) => {
+  _putRulePrams: function(params) {
     return {
       Name: params.ScheduleName,
-      Description: ScheduleEvents._ruleDescription(params),
+      Description: this._ruleDescription(params),
       State: params.ScheduleState,
       ScheduleExpression: params.ScheduleExpression
     };
   },
 
-  _putRule: (params) => {
+  _putRule: function(params) {
+    const _this = this;
     // return RuleArn if created
     return new Promise((resolve) => {
-      const _params = ScheduleEvents._putRulePrams(params);
-      cloudwatchevents.putRule(_params, (err, rule) => {
+      const _params = _this._putRulePrams(params);
+      _this.cloudwatchevents.putRule(_params, (err, rule) => {
         if (err) throw err;
         resolve(rule);
       });
@@ -47,10 +50,11 @@ const ScheduleEvents = {
     };
   },
 
-  _addPermission: (params) => {
+  _addPermission: function(params) {
+    const _this = this;
     return new Promise((resolve) => {
-      const _params = ScheduleEvents._addPermissionParams(params);
-      lambda.addPermission(_params, (err, data) => {
+      const _params = _this._addPermissionParams(params);
+      _this.lambda.addPermission(_params, (err, data) => {
         if (err) {
           if (err.code != 'ResourceConflictException') throw err;
           // If it exists it will result in an error but there is no problem.
@@ -61,20 +65,21 @@ const ScheduleEvents = {
     });
   },
 
-  _putTargetsParams: (params) => {
+  _putTargetsParams: function(params) {
     return {
       Rule: params.ScheduleName,
       Targets: [{
-        Arn: ScheduleEvents._functionArn(params),
+        Arn: this._functionArn(params),
         Id: params.FunctionName
       }]
     };
   },
 
-  _putTargets: (params) => {
+  _putTargets: function(params) {
+    const _this = this;
     return new Promise((resolve) => {
-      const _params = ScheduleEvents._putTargetsParams(params);
-      cloudwatchevents.putTargets(_params, (err, data) => {
+      const _params = _this._putTargetsParams(params);
+      _this.cloudwatchevents.putTargets(_params, (err, data) => {
         // even if it is already registered, it will not be an error.
         if (err) throw(err);
         resolve(data);
@@ -82,13 +87,14 @@ const ScheduleEvents = {
     });
   },
 
-  add: (params) => {
+  add: function(params) {
+    const _this = this;
     return Promise.resolve().then(() => {
-      return ScheduleEvents._putRule(params);
+      return _this._putRule(params);
     }).then((rule) => {
-      return ScheduleEvents._addPermission(Object.assign(params, rule));
+      return _this._addPermission(Object.assign(params, rule));
     }).then((data) => {
-      return ScheduleEvents._putTargets(params);
+      return _this._putTargets(params);
     });
   },
 };

--- a/test/schedule_events.js
+++ b/test/schedule_events.js
@@ -4,6 +4,7 @@ const assert = require('chai').assert;
 const path = require('path');
 const aws = require('aws-sdk-mock');
 aws.setSDK(path.resolve('node_modules/aws-sdk'));
+const ScheduleEvents = require(path.join('..', 'lib', 'schedule_events'));
 
 const params = {
   FunctionName: 'node-lambda-test-function',
@@ -49,7 +50,7 @@ describe('schedule_events', () => {
       callback(null, mockResponse.addPermission);
     });
 
-    schedule = require(path.join('..', 'lib', 'schedule_events'));
+    schedule = new ScheduleEvents(require('aws-sdk'));
   });
 
   describe('_ruleDescription', () => {


### PR DESCRIPTION
Consideration about authentication was missing.
Fix to use `aws` object with authentication setting in main.js