### PR TITLE
Set http timeout to 30 mins. 

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -13,6 +13,7 @@ var dotenv = require('dotenv');
 var ScheduleEvents = require('./schedule_events');
 
 var maxBufferSize = 50 * 1024 * 1024;
+aws.config.httpOptions.timeout = 30 * 60 * 1000;
 
 var Lambda = function () {
   this.version = packageJson.version;
@@ -371,7 +372,7 @@ Lambda.prototype._setRunTimeEnvironmentVars = function (program) {
 };
 
 Lambda.prototype._uploadExisting = function (lambda, params, cb) {
-  return lambda.updateFunctionCode({
+  var request = lambda.updateFunctionCode({
     'FunctionName': params.FunctionName,
     'ZipFile': params.Code.ZipFile,
     'Publish': params.Publish
@@ -395,12 +396,26 @@ Lambda.prototype._uploadExisting = function (lambda, params, cb) {
       return cb(err, data);
     });
   });
+
+  request.on('retry', function (response) {
+    console.log(response.error.message);
+    console.log('=> Retrying');
+  });
+
+  return request;
 };
 
 Lambda.prototype._uploadNew = function (lambda, params, cb) {
-  return lambda.createFunction(params, function (err, data) {
+  var request = lambda.createFunction(params, function (err, data) {
     return cb(err, data);
   });
+
+  request.on('retry', function (response) {
+    console.log(response.error.message);
+    console.log('=> Retrying');
+  });
+
+  return request;
 };
 
 Lambda.prototype._readArchive = function (program, archive_callback) {


### PR DESCRIPTION
By default aws only allows the http request 2 minutes to upload. This PR increases the limit to 30 minutes. It will also report when a request is being retried and including the reason why.

I was trying to upload 8megs at home. It was taking 8 minutes to report a fail. This was because it uploads for 2 mins, waiting for 1 min and attempts twice more.

Thanks.