### PR TITLE
Fix to avoid `commander` bug

### DIFF
--- a/bin/node-lambda
+++ b/bin/node-lambda
@@ -1,5 +1,39 @@
 #!/usr/bin/env node
 
+'use strict';
+
+// Temporary correspondence in case usage is not displayed correctly
+// due to `commander` bug.
+// It seems that development of the `commander` project is also stopped
+const commandTypes = [
+  'deploy',
+  'package',
+  'zip',
+  'run',
+  'execute',
+  'setup',
+];
+if (commandTypes.indexOf(process.argv[2]) == -1) {
+  console.log(
+`
+  Usage: node-lambda [options] [command]
+
+
+  Commands:
+
+    deploy [options]        Deploy your application to Amazon Lambda
+    package|zip [options]   Create zipped package for Amazon Lambda deployment
+    run|execute [options]   Run your Amazon Lambda application locally
+    setup [options]         Sets up the .env file.
+
+  Options:
+
+    -h, --help  output usage information
+`
+  );
+  process.exit(1);
+}
+
 var dotenv = require('dotenv');
 var lambda = require('../lib/main.js');
 var program = require('commander');


### PR DESCRIPTION
Temporary correspondence in case usage is not displayed correctly due to `commander` bug.
It seems that development of the `commander` project is also stopped.