### PR TITLE
Prevent empty deadLetterQueue TargetArns

### DIFF
--- a/.build_1493180045112/package.json
+++ b/.build_1493180045112/package.json
@@ -1,0 +1,1 @@
+undefined

--- a/.build_1493180045112/testa
+++ b/.build_1493180045112/testa
@@ -1,0 +1,1 @@
+undefined

--- a/.build_1493180045214/package.json
+++ b/.build_1493180045214/package.json
@@ -1,0 +1,1 @@
+undefined

--- a/.build_1493180045214/testa
+++ b/.build_1493180045214/testa
@@ -1,0 +1,1 @@
+undefined

--- a/lib/main.js
+++ b/lib/main.js
@@ -131,7 +131,7 @@ Lambda.prototype._params = function (program, buffer) {
       Variables: config
     }
   }
-  if (program.deadLetterConfigTargetArn !== undefined) {
+  if (program.deadLetterConfigTargetArn !== undefined && program.deadLetterConfigTargetArn !== '' && program.deadLetterConfigTargetArn !== null) {
     params.DeadLetterConfig = {
       TargetArn: program.deadLetterConfigTargetArn
     };

--- a/lib/main.js
+++ b/lib/main.js
@@ -136,8 +136,10 @@ Lambda.prototype._params = function (program, buffer) {
       TargetArn: program.deadLetterConfigTargetArn
     };
   }
-  if (program.tracingConfig) {
+  if (program.tracingConfig !== undefined && program.tracingConfig !== '' && program.tracingConfig !== null) {
     params.TracingConfig.Mode = program.tracingConfig;
+  } else {
+    delete params.TracingConfig;
   }
 
   return params;

--- a/test/main.js
+++ b/test/main.js
@@ -107,7 +107,7 @@ describe('node-lambda', function () {
     it('does not append TracingConfig when params are not set', function() {
       program.tracingConfig = '';
       const params = lambda._params(program);
-      assert.isNull(params.TracingConfig.Mode);
+      assert.isUndefined(params.TracingConfig);
     });
 
     describe('configFile', function () {

--- a/test/main.js
+++ b/test/main.js
@@ -85,7 +85,7 @@ describe('node-lambda', function () {
     });
 
     it('appends DeadLetterConfig to params when DLQ params set', function() {
-      ['', 'arn:aws:sqs:test'].forEach(function(v) {
+      ['arn:aws:sqs:test'].forEach(function(v) {
         program.deadLetterConfigTargetArn = v;
         const params = lambda._params(program);
         assert.equal(params.DeadLetterConfig.TargetArn, v, v);


### PR DESCRIPTION
Commander can return an option as an empty string. Empty strings are invalid ARNs and the AWS SDK will fail. Ignore empty strings if they are sent through.