### PR TITLE
Fix `fs.exists` deprecated

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -288,22 +288,20 @@ Lambda.prototype._postInstallScript = function (program, codeDirectory, callback
 
   var filePath = path.join(codeDirectory, scriptFilename);
 
-  fs.exists(filePath, function (exists) {
-    if (exists) {
-      console.log('=> Running post install script ' + scriptFilename);
-      exec(cmd, { env: process.env, cwd: codeDirectory, maxBuffer: maxBufferSize },
-        function (error, stdout, stderr) {
-
-        if (error) {
-          callback(error + " stdout: " + stdout + " stderr: " + stderr);
-        } else {
-          console.log("\t\t" + stdout);
-          callback(null);
-        }
-      });
-    } else {
-      callback(null);
+  if (!fs.existsSync(filePath)) {
+    return callback(null);
+  }
+  console.log('=> Running post install script ' + scriptFilename);
+  exec(cmd, {
+    env: process.env,
+    cwd: codeDirectory,
+    maxBuffer: maxBufferSize
+  }, function (error, stdout, stderr) {
+    if (error) {
+      return callback(error + " stdout: " + stdout + " stderr: " + stderr);
     }
+    console.log("\t\t" + stdout);
+    callback(null);
   });
 };
 


### PR DESCRIPTION
Fixed as `fs.exists` was deprecated.
https://nodejs.org/api/fs.html#fs_fs_exists_path_callback

I added a test when the command failed.