### PR TITLE
Bugfix `_filecopy` exclude

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -203,11 +203,20 @@ Lambda.prototype._fileCopy = function (program, src, dest, excludeNodeModules, c
     .concat(excludeNodeModules ? ['/node_modules'] : []);
   })();
 
+  // Formatting for `filter` of `fs.copy`
+  const dirBlobs = [];
   const pattern = '{' + excludes.map(function (str) {
+    if (str.match(/\/$/)) {
+      str = str.substr(0, str.length - 1);
+      dirBlobs.push(str);
+    }
+    if (str.charAt('0') == '/')
+      return path.join(srcAbsolutePath, str);
     if (str.indexOf('/') >= 0)
-      return path.join(srcAbsolutePath, str.replace(/\/$/, ''));
+      return path.join(path.resolve('/**'), str);
     return str;
-  }).join(',') + '}'
+  }).join(',') + '}';
+  const dirPatternRegExp = new RegExp(`(${dirBlobs.join('|')})$`);
 
   fs.mkdirs(dest, function (err) {
     if (err) {
@@ -220,7 +229,13 @@ Lambda.prototype._fileCopy = function (program, src, dest, excludeNodeModules, c
           // include package.json unless prebuiltDirectory is set
           return true;
         }
-        return !minimatch(src, pattern, { matchBase: true });
+
+        if (!minimatch(src, pattern, { matchBase: true }))
+          return true;
+        // Directory check. Even if `src` is a directory it will not end with '/'.
+        if (!dirPatternRegExp.test(src))
+          return false;
+        return !fs.statSync(src).isDirectory();
       }
     };
     fs.copy(src, dest, options, function (err) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -206,13 +206,13 @@ Lambda.prototype._fileCopy = function (program, src, dest, excludeNodeModules, c
   // Formatting for `filter` of `fs.copy`
   const dirBlobs = [];
   const pattern = '{' + excludes.map(function (str) {
-    if (str.match(/\/$/)) {
+    if (str.charAt(str.length - 1) == path.sep) {
       str = str.substr(0, str.length - 1);
       dirBlobs.push(str);
     }
-    if (str.charAt('0') == '/')
+    if (str.charAt(0) == path.sep)
       return path.join(srcAbsolutePath, str);
-    if (str.indexOf('/') >= 0)
+    if (str.indexOf(path.sep) >= 0)
       return path.join(path.resolve('/**'), str);
     return str;
   }).join(',') + '}';

--- a/lib/main.js
+++ b/lib/main.js
@@ -204,8 +204,8 @@ Lambda.prototype._fileCopy = function (program, src, dest, excludeNodeModules, c
   })();
 
   const pattern = '{' + excludes.map(function (str) {
-    if (str.charAt(0) == '/')
-      return path.join(srcAbsolutePath, str);
+    if (str.indexOf('/') >= 0)
+      return path.join(srcAbsolutePath, str.replace(/\/$/, ''));
     return str;
   }).join(',') + '}'
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -197,7 +197,7 @@ Lambda.prototype._fileCopy = function (program, src, dest, excludeNodeModules, c
       '.editorconfig',
       'deploy.env',
       '*.log',
-      path.join(path.sep, 'build', path.sep);
+      path.join(path.sep, 'build', path.sep)
     ]
     .concat(program.excludeGlobs ? program.excludeGlobs.split(' ') : [])
     .concat(excludeNodeModules ? [path.join(path.sep, 'node_modules')] : []);

--- a/lib/main.js
+++ b/lib/main.js
@@ -197,10 +197,10 @@ Lambda.prototype._fileCopy = function (program, src, dest, excludeNodeModules, c
       '.editorconfig',
       'deploy.env',
       '*.log',
-      '/build/'
+      path.join(path.sep, 'build', path.sep);
     ]
     .concat(program.excludeGlobs ? program.excludeGlobs.split(' ') : [])
-    .concat(excludeNodeModules ? ['/node_modules'] : []);
+    .concat(excludeNodeModules ? [path.join(path.sep, 'node_modules')] : []);
   })();
 
   // Formatting for `filter` of `fs.copy`

--- a/test/main.js
+++ b/test/main.js
@@ -215,7 +215,7 @@ describe('node-lambda', function () {
           'test',
           '*main*',
           path.join('__unittest', 'hoge', '*'),
-          'fuga/'
+          path.join('fuga', path.sep)
         ].join(' ');
         done();
       });


### PR DESCRIPTION
Thank you for always checking.
I fixed the place I noticed after confirming the operation in my environment.
Since I could do `deploy` without any problem in my environment, open PR which replaces` _rsync` with `_fileCopy` next time.