### PR TITLE
Fix to replace `_rsync` with `_fileCopy`

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -452,7 +452,16 @@ Lambda.prototype._archive = function (program, archive_callback) {
 Lambda.prototype._archivePrebuilt = function (program, archive_callback) {
   var codeDirectory = this._codeDirectory(program);
   var _this = this;
-  this._rsync(program, program.prebuiltDirectory, codeDirectory, false, function (err) {
+
+  // It is switched to `_ rsync` by environment variable.
+  // (Used if there is a problem with `_ fileCopy`)
+  // If there is no problem even if deleting `_rsync`, this switching process is deleted
+  var copyFunction = '_fileCopy';
+  if (process.env.NODE_LAMBDA_COPY_FUNCTION == 'rsync') {
+    console.log('=> INFO: Use rsync for copy');
+    copyFunction = '_rsync';
+  }
+  this[copyFunction](program, program.prebuiltDirectory, codeDirectory, false, function (err) {
     if (err) {
       return archive_callback(err);
     }
@@ -484,8 +493,17 @@ Lambda.prototype._buildAndArchive = function (program, archive_callback) {
       return archive_callback(err);
     }
     console.log('=> Moving files to temporary directory');
+
+    // It is switched to `_ rsync` by environment variable.
+    // (Used if there is a problem with `_ fileCopy`)
+    // If there is no problem even if deleting `_rsync`, this switching process is deleted
+    var copyFunction = '_fileCopy';
+    if (process.env.NODE_LAMBDA_COPY_FUNCTION == 'rsync') {
+      console.log('=> INFO: Use rsync for copy');
+      copyFunction = '_rsync';
+    }
     // Move files to tmp folder
-    _this._rsync(program, '.', codeDirectory, true, function (err) {
+    _this[copyFunction](program, '.', codeDirectory, true, function (err) {
       if (err) {
         return archive_callback(err);
       }

--- a/lib/main.js
+++ b/lib/main.js
@@ -249,6 +249,7 @@ Lambda.prototype._fileCopy = function (program, src, dest, excludeNodeModules, c
   });
 };
 
+// `_rsync` will be replaced by` _fileCopy`.
 Lambda.prototype._rsync = function (program, src, dest, excludeNodeModules, callback) {
   var excludes = ['.git*', '*.swp', '.editorconfig', '.lambda', 'deploy.env', '*.log', '/build/'],
       excludeGlobs = [];

--- a/test/main.js
+++ b/test/main.js
@@ -285,8 +285,12 @@ describe('node-lambda', function () {
     });
   }
 
-  describe('_rsync', function() { rsyncTests('_rsync'); });
   describe('_fileCopy', function() { rsyncTests('_fileCopy'); });
+  if (process.platform == 'win32') {
+    it('For Windows, `_rsync` tests pending');
+  } else {
+    describe('_rsync', function() { rsyncTests('_rsync'); });
+  }
 
   describe('_npmInstall', function () {
     beforeEach(function (done) {

--- a/test/main.js
+++ b/test/main.js
@@ -162,7 +162,7 @@ describe('node-lambda', function () {
     });
 
     it('`codeDirectory` is empty. (For `codeDirectory` where the file was present)', function (done) {
-      lambda._rsync(program, '.', codeDirectory, true, function (err, result) {
+      lambda._fileCopy(program, '.', codeDirectory, true, function (err, result) {
         const contents = fs.readdirSync(codeDirectory);
         assert.isTrue(contents.length > 0);
         lambda._cleanDirectory(codeDirectory, function () {
@@ -295,7 +295,7 @@ describe('node-lambda', function () {
           return done(err);
         }
 
-        lambda._rsync(program, '.', codeDirectory, true, function (err) {
+        lambda._fileCopy(program, '.', codeDirectory, true, function (err) {
           if (err) {
             return done(err);
           }
@@ -381,7 +381,7 @@ describe('node-lambda', function () {
           return done(err);
         }
 
-        lambda._rsync(program, '.', codeDirectory, true, function (err) {
+        lambda._fileCopy(program, '.', codeDirectory, true, function (err) {
           if (err) {
             return done(err);
           }


### PR DESCRIPTION
In preparation for a problem, processing that can be switched by environment variable is put in place.
If the next version has been released and there are no major problems, Replace with `_fileCopy`.