### PR TITLE
Custom ScheduleEvent rule description

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,13 @@ The `--prebuiltDirectory` flag is useful for working with Webpack for example. I
 ## Handling `npm link` and Dependencies With Local Paths
 Perhaps the easiest way to handle these cases is to bundle the code using Webpack and use the `--prebuiltDirectory` flag to package the output for deployment.
 
+## ScheduleEvents
+#### Optional Parameter
+When using the eventSourceFile flag (-S or --eventSourceFile) to set a ScheduleEvent trigger, you can pass an optional _ScheduleDescription_ key into the ScheduleEvent object with a custom description for the CloudWatch event rule you are defining. By default, node-lambda generates a _ScheduleDescription_ for you based on the ScheduleName and ScheduleExpression of the rule.
+
+#### Note on ScheduleState for ScheduleEvents
+When setting ScheduleState to `ENABLED` or `DISABLED` for ScheduleEvents, it is useful to note that this sets the state of the CloudWatch Event rule but _DOES NOT_ set the state of the trigger for the Lambda function you are deploying; ScheduleEvent triggers are enabled by default in the Lambda console when added using the eventSourceFile flag.
+
 ## Other AWS Lambda Tools Projects
 
 + [lambdaws](https://github.com/mentum/lambdaws)

--- a/lib/event_sources.json.example
+++ b/lib/event_sources.json.example
@@ -11,8 +11,7 @@
     {
       "ScheduleName": "node-lambda-test-schedule",
       "ScheduleState": "ENABLED",
-      "ScheduleExpression": "rate(1 hour)",
-      "ScheduleDescription": "Run node-lambda-test-function once per hour"
+      "ScheduleExpression": "rate(1 hour)"
     }
   ]
 }

--- a/lib/event_sources.json.example
+++ b/lib/event_sources.json.example
@@ -11,7 +11,8 @@
     {
       "ScheduleName": "node-lambda-test-schedule",
       "ScheduleState": "ENABLED",
-      "ScheduleExpression": "rate(1 hour)"
+      "ScheduleExpression": "rate(1 hour)",
+      "ScheduleDescription": "Run node-lambda-test-function once per hour"
     }
   ]
 }

--- a/lib/schedule_events.js
+++ b/lib/schedule_events.js
@@ -12,7 +12,7 @@ const ScheduleEvents = function(aws) {
 
 ScheduleEvents.prototype = {
   _ruleDescription: (params) => {
-    if (params.ScheduleDescription != null) {
+    if ('ScheduleDescription' in params && params.ScheduleDescription != null) {
       return `${params.ScheduleDescription}`;
     } else {
       return `${params.ScheduleName} - ${params.ScheduleExpression}`;

--- a/lib/schedule_events.js
+++ b/lib/schedule_events.js
@@ -12,7 +12,11 @@ const ScheduleEvents = function(aws) {
 
 ScheduleEvents.prototype = {
   _ruleDescription: (params) => {
-    return `${params.ScheduleName} - ${params.ScheduleExpression}`;
+    if (params.ScheduleDescription != null) {
+      return `${params.ScheduleDescription}`;
+    } else {
+      return `${params.ScheduleName} - ${params.ScheduleExpression}`;
+    }
   },
 
   _functionName: (params) => {

--- a/test/main.js
+++ b/test/main.js
@@ -647,8 +647,7 @@ describe('node-lambda', function () {
             ScheduleEvents: [{
               ScheduleName: 'node-lambda-test-schedule',
               ScheduleState: 'ENABLED',
-              ScheduleExpression: 'rate(1 hour)',
-              ScheduleDescription: 'Run node-lambda-test-function once per hour'
+              ScheduleExpression: 'rate(1 hour)'
             }],
           };
           assert.deepEqual(lambda._eventSourceList(program), expected);

--- a/test/main.js
+++ b/test/main.js
@@ -648,6 +648,7 @@ describe('node-lambda', function () {
               ScheduleName: 'node-lambda-test-schedule',
               ScheduleState: 'ENABLED',
               ScheduleExpression: 'rate(1 hour)',
+              ScheduleDescription: 'Run node-lambda-test-function once per hour'
             }],
           };
           assert.deepEqual(lambda._eventSourceList(program), expected);
@@ -691,6 +692,7 @@ describe('node-lambda', function () {
         ScheduleName: 'node-lambda-test-schedule',
         ScheduleState: 'ENABLED',
         ScheduleExpression: 'rate(1 hour)',
+        ScheduleDescription: 'Run node-lambda-test-function once per hour'
       }]
     };
 

--- a/test/schedule_events.js
+++ b/test/schedule_events.js
@@ -10,7 +10,8 @@ const params = {
   FunctionArn: 'arn:aws:lambda:us-west-2:XXX:function:node-lambda-test-function',
   ScheduleName: 'node-lambda-test-schedule',
   ScheduleState: 'ENABLED',
-  ScheduleExpression: 'rate(1 hour)'
+  ScheduleExpression: 'rate(1 hour)',
+  ScheduleDescription: null
 };
 
 const mockResponse = {
@@ -52,11 +53,28 @@ describe('schedule_events', () => {
     schedule = new ScheduleEvents(require('aws-sdk'));
   });
 
-  describe('_ruleDescription', () => {
+  describe('_ruleDescription (default)', () => {
     it('correct value', () => {
       assert.equal(
         schedule._ruleDescription(params),
         'node-lambda-test-schedule - rate(1 hour)'
+      );
+    });
+  });
+
+  describe('_ruleDescription (custom)', () => {
+    before(() => {
+      params.ScheduleDescription = 'Run node-lambda-test-function once per hour';
+    });
+
+    after(() => {
+      params.ScheduleDescription = null;
+    });
+
+    it('correct value', () => {
+      assert.equal(
+        schedule._ruleDescription(params),
+        'Run node-lambda-test-function once per hour'
       );
     });
   });


### PR DESCRIPTION
This PR adds the ability to provide a custom description for a ScheduleEvent rule in the eventSourceFile. Although I find the default description of `params.ScheduleName - params.ScheduleExpression` to be sufficient in most cases, I think it would be useful to also have the ability to provide a custom description for these rules.