### PR TITLE
escape disallowed characters

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -92,7 +92,9 @@ Lambda.prototype._runHandler = function (handler, event, program, context) {
 
 Lambda.prototype._params = function (program, buffer) {
   var params = {
-    FunctionName: program.functionName + (program.environment ? '-' + program.environment : ''),
+    FunctionName: program.functionName
+      + (program.environment ? '-' + program.environment : '')
+      + (program.lambdaVersion ? '-' + program.lambdaVersion : ''),
     Code: {
       ZipFile: buffer
     },
@@ -117,9 +119,10 @@ Lambda.prototype._params = function (program, buffer) {
       Mode: null
     }
   };
-  if (program.lambdaVersion) {
-    params.FunctionName += ('-' + program.lambdaVersion);
-  }
+
+  // Escape characters that is not allowed by AWS Lambda
+  params.FunctionName = params.FunctionName.replace(/[^a-zA-Z0-9-_]/g, '_');
+
   if (program.vpcSubnets && program.vpcSecurityGroups) {
     params.VpcConfig = {
       'SubnetIds': program.vpcSubnets.split(','),


### PR DESCRIPTION
When I was trying `-L` argument, I found that the deployment will be rejected if I assign the lambda version with `v1.0.0`, and then I figure out the version will be appended to the function name which makes the function name being illegal.

As [AWS Lambda mentioned](http://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-FunctionName) in the `CreateFunction` API document, function name only allows `[a-zA-Z0-9-_]+`, any disallowed character will be replaced with `_` by this PR.