### PR TITLE
Added `- cwd` option to `npm install` command

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -290,9 +290,13 @@ Lambda.prototype._rsync = function (program, src, dest, excludeNodeModules, call
 };
 
 Lambda.prototype._npmInstall = function (program, codeDirectory, callback) {
+  const installOptions = [
+    `--prefix ${codeDirectory}`,
+    process.platform === 'win32' ? `--cwd ${codeDirectory}` : null,
+  ].join(' ');
   var command = program.dockerImage ?
     'docker run --rm -v ' + codeDirectory + ':/var/task ' + program.dockerImage + ' npm -s install --production' :
-    `npm -s install --production --prefix ${codeDirectory} --cwd ${codeDirectory}`;
+    `npm -s install --production ${installOptions}`;
   exec(command, {
     maxBuffer: maxBufferSize,
     env: process.env

--- a/lib/main.js
+++ b/lib/main.js
@@ -288,7 +288,7 @@ Lambda.prototype._rsync = function (program, src, dest, excludeNodeModules, call
 Lambda.prototype._npmInstall = function (program, codeDirectory, callback) {
   var command = program.dockerImage ?
     'docker run --rm -v ' + codeDirectory + ':/var/task ' + program.dockerImage + ' npm -s install --production' :
-    'npm -s install --production --prefix ' + codeDirectory;
+    `npm -s install --production --prefix ${codeDirectory} --cwd ${codeDirectory}`;
   exec(command, {
     maxBuffer: maxBufferSize,
     env: process.env


### PR DESCRIPTION
Because `Refusing to install node - lambda as a dependency of itself`
error occurs on Windows

===> In my Windows environment.
All unit test passes on Windows.
Also confirmed that `setup`,` package`, `run`,` deploy` worked. (Conducted only simple confirmation)