### PR TITLE
Fix not to create `.env` sample file with `_buildAndArchive`

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -483,7 +483,10 @@ Lambda.prototype._archivePrebuilt = function (program, archive_callback) {
 };
 
 Lambda.prototype._buildAndArchive = function (program, archive_callback) {
-  this._createSampleFile('.env', '.env');
+  if (!fs.existsSync('.env')) {
+    console.warn('[Warning] `.env` file does not exist.');
+    console.info('Execute `node-lambda setup` as necessary and set it up.');
+  }
 
   // Warn if not building on 64-bit linux
   var arch = process.platform + '.' + process.arch;


### PR DESCRIPTION
It appeared that it was not necessary to create the `.env` sample file with` _buildAndArchive`.
So, I only displayed a warning message.
Are there any possible adverse effects?