### PR TITLE
Fix os: deprecate 'tmpDir()' in favour of 'tmpdir()' https://github.c…

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -186,7 +186,7 @@ Lambda.prototype._eventSourceList = function (program) {
 Lambda.prototype._zipfileTmpPath = function (program) {
   var ms_since_epoch = +new Date();
   var filename = program.functionName + '-' + ms_since_epoch + '.zip';
-  var zipfile = path.join(os.tmpDir(), filename);
+  var zipfile = path.join(os.tmpdir(), filename);
 
   return zipfile;
 };

--- a/test/main.js
+++ b/test/main.js
@@ -58,7 +58,7 @@ describe('node-lambda', function () {
 
   after(function () {
     _timeout({ this: this, sec: 30 }); // give it time to remove
-    fs.removeSync(path.join(os.tmpDir(), `${program.functionName}-[0-9]*`));
+    fs.removeSync(path.join(os.tmpdir(), `${program.functionName}-[0-9]*`));
   });
 
   it('version should be set', function () {
@@ -493,7 +493,7 @@ describe('node-lambda', function () {
   });
 
   describe('_readArchive', function () {
-    const testZipFile = path.join(os.tmpDir(), 'node-lambda-test.zip');
+    const testZipFile = path.join(os.tmpdir(), 'node-lambda-test.zip');
     var bufferExpected = null;
     before(function(done) {
       _timeout({ this: this, sec: 30 }); // give it time to zip


### PR DESCRIPTION
Hi all
In this pull request i fix deprecation warning for old method os.tmpDir()