### PR TITLE
Remove function `_nativeZip`

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -180,17 +180,6 @@ Lambda.prototype._eventSourceList = function (program) {
   return list;
 };
 
-/**
- * @deprecated
- */
-Lambda.prototype._zipfileTmpPath = function (program) {
-  var msSinceEpoch = +new Date();
-  var filename = program.functionName + '-' + msSinceEpoch + '.zip';
-  var zipfile = path.join(os.tmpdir(), filename);
-
-  return zipfile;
-};
-
 Lambda.prototype._fileCopy = function (program, src, dest, excludeNodeModules, callback) {
   const srcAbsolutePath = path.resolve(src);
   const excludes = (function () {
@@ -353,24 +342,6 @@ Lambda.prototype._zip = function (program, codeDirectory, callback) {
     });
 };
 
-Lambda.prototype._nativeZip = function (program, codeDirectory, callback) {
-  var zipfile = this._zipfileTmpPath(program),
-    cmd = 'zip -r ' + zipfile + ' .';
-
-  exec(cmd, {
-    env: process.env,
-    cwd: codeDirectory,
-    maxBuffer: maxBufferSize
-  }, function (err) {
-    if (err !== null) {
-      return callback(err, null);
-    }
-
-    var data = fs.readFileSync(zipfile);
-    callback(null, data);
-  });
-};
-
 Lambda.prototype._codeDirectory = function () {
   return path.resolve('.', '.lambda');
 };
@@ -487,10 +458,7 @@ Lambda.prototype._archivePrebuilt = function (program, archiveCallback) {
     }
 
     console.log('=> Zipping deployment package');
-    var archive = process.platform !== 'win32' ? _this._nativeZip : _this._zip;
-    archive = archive.bind(_this);
-
-    archive(program, codeDirectory, archiveCallback);
+    _this._zip(program, codeDirectory, archiveCallback);
   });
 };
 
@@ -543,11 +511,7 @@ Lambda.prototype._buildAndArchive = function (program, archiveCallback) {
           }
 
           console.log('=> Zipping deployment package');
-
-          var archive = process.platform !== 'win32' ? _this._nativeZip : _this._zip;
-          archive = archive.bind(_this);
-
-          archive(program, codeDirectory, archiveCallback);
+          _this._zip(program, codeDirectory, archiveCallback);
         });
       });
     });

--- a/test/main.js
+++ b/test/main.js
@@ -178,14 +178,6 @@ describe('node-lambda', function () {
     });
   });
 
-  describe('_zipfileTmpPath', function () {
-    it('has the correct path', function () {
-      var zipfileTmpPath = lambda._zipfileTmpPath(program);
-      var value = zipfileTmpPath.indexOf(program.functionName) > 0;
-      assert.equal(value, true);
-    });
-  });
-
   describe('_cleanDirectory', function () {
     it('`codeDirectory` is empty', function (done) {
       lambda._cleanDirectory(codeDirectory, function () {
@@ -469,6 +461,7 @@ describe('node-lambda', function () {
     });
 
     it('packages a prebuilt module without installing', function (done) {
+      _timeout({ this: this, sec: 30 }); // give it time to zip
       var buildDir = '.build_' + Date.now();
       after(function() {
         rimraf.sync(buildDir, fs);


### PR DESCRIPTION
Since it works without problems with `_zip` it has removed `_nativeZip`.
Unnecessary temporary files(`_zipfileTmpPath`) will not be created.