### PR TITLE
Add known issue for duplicate trigger to ScheduleEvents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ When using the eventSourceFile flag (-S or --eventSourceFile) to set a ScheduleE
 #### Note on ScheduleState for ScheduleEvents
 When setting ScheduleState to `ENABLED` or `DISABLED` for ScheduleEvents, it is useful to note that this sets the state of the CloudWatch Event rule but _DOES NOT_ set the state of the trigger for the Lambda function you are deploying; ScheduleEvent triggers are enabled by default in the Lambda console when added using the eventSourceFile flag.
 
+#### Known Issue
+###### Duplicate ScheduleEvent Triggers
+If you are adding a trigger via the `eventSourceFile` for the first time, remove preexisting triggers from the Lambda console before deploying. Deploying a Lambda with the `--eventSourceFile` flag will *NOT* overwrite the same triggers created from the AWS console and may result in a duplicate triggers for the same rule.
+
 ## Other AWS Lambda Tools Projects
 
 + [lambdaws](https://github.com/mentum/lambdaws)
@@ -237,4 +241,3 @@ When setting ScheduleState to `ENABLED` or `DISABLED` for ScheduleEvents, it is 
 $ npm install
 $ npm test
 ```
-


### PR DESCRIPTION
I have done some digging into what could possibly be causing this issue, but to no avail. It seems as though the `ResourceConflictException` error that is expected if a resource already exists doesn't get returned when the previously created resource is one that was created via the Lambda console for ScheduleEvent triggers- [see this line in schedule_events.js](https://github.com/motdotla/node-lambda/blob/master/lib/schedule_events.js#L63) to see where this error is expected to be present for existing resources.

So, if the trigger you're trying to add to the Lambda is already there because it was added manually via the Lambda UI/console, including it via the `eventSourceFile` will result in a duplicate trigger being added since the Lambda SDK interprets those as separate resources for some reason (even though the **SourceArn** is identical).

I can try to work on a fix for this later this week/weekend, but for now I figured including it in the docs might be useful if anyone out there is experiencing this issue.

If you'd like to recreate the issue for yourself, try the following:

-   In the trigger section for a Lambda- click on Add Trigger
-   In the next prompt, select CloudWatch Events - Schedule
-   Next, select the rule you want and **Submit**.
    -   You should now see a CloudWatch Event trigger for your function in the console
-   Next, include the same event rule in your eventSourceFile and deploy.
-   Finally, return to the triggers section in the Lambda console and you will see 2 identical triggers for your lambda.