### PR TITLE
Fix run handler callback

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -69,7 +69,7 @@ Lambda.prototype._runHandler = function (handler, event, program, context) {
   var callback = function (err, result) {
     if (err) {
       console.log('Error: ' + err);
-      process.exit(-1);
+      process.exit(255);
     }
     console.log('Success:');
     if (!result) {
@@ -85,7 +85,7 @@ Lambda.prototype._runHandler = function (handler, event, program, context) {
 
   if (['nodejs4.3', 'nodejs6.10'].indexOf(program.runtime) == -1) {
     console.error("Runtime [" + program.runtime + "] is not supported.");
-    process.exit(-2);
+    process.exit(254);
   }
   handler(event, context, callback);
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -72,10 +72,10 @@ Lambda.prototype._runHandler = function (handler, event, program, context) {
       process.exit(-1);
     }
     console.log('Success:');
-    if (result) {
-      console.log(JSON.stringify(result));
+    if (!result) {
+      process.exit(0);
     }
-    process.exit(0);
+    console.log(JSON.stringify(result));
   };
 
   context.getRemainingTimeInMillis = function () {

--- a/test/main.js
+++ b/test/main.js
@@ -852,6 +852,8 @@ describe('node-lambda', function () {
   });
 
   describe('node-lambda run', function () {
+    // The reason for specifying the node command in this test is to support Windows.
+
     const nodeLambdaPath = path.join('bin', 'node-lambda');
     const _generateHandlerFile = function (callbackString) {
       fs.writeFileSync(

--- a/test/main.js
+++ b/test/main.js
@@ -9,7 +9,6 @@ var Hoek = require('hoek');
 var lambda = require(path.join(__dirname, '..', 'lib', 'main'));
 var zip = require('node-zip');
 var rimraf = require('rimraf');
-var spawn = require('child_process').spawn;
 
 var assert = chai.assert;
 
@@ -46,7 +45,7 @@ function _timeout(params) {
   }
 }
 
-describe('node-lambda', function () {
+describe('lib/main', function () {
   if (process.platform == 'win32') {
     // It seems that it takes time for file operation in Windows.
     // So set `timeout(60000)` for the whole test.
@@ -847,86 +846,6 @@ describe('node-lambda', function () {
           fs.readFileSync(boilerplateFile).toString(),
           targetFile
         );
-      });
-    });
-  });
-
-  describe('node-lambda run', function () {
-    // The reason for specifying the node command in this test is to support Windows.
-
-    const nodeLambdaPath = path.join('bin', 'node-lambda');
-    const _generateHandlerFile = function (callbackString) {
-      fs.writeFileSync(
-        '__test.js',
-        fs.readFileSync('index.js').toString()
-          .replace(/callback\(null\);/, callbackString)
-      );
-    };
-
-    before(function () {
-      // Restore default value
-      program.eventFile = 'event.json';
-      program.contextFile = 'context.json';
-
-      lambda.setup(program);
-    });
-
-    after(function () {
-      [
-        '.env',
-        'context.json',
-        'event.json',
-        'deploy.env',
-        'event_sources.json',
-        '__test.js'
-      ].forEach(function(file) {
-        fs.unlinkSync(file);
-      });
-    });
-
-    it('`node-lambda run` exitCode is `0` (callback(null))', function (done) {
-      const run = spawn('node', [nodeLambdaPath, 'run']);
-      var stdoutString = '';
-      run.stdout.on('data', function (data) {
-        stdoutString += data.toString().replace(/\r|\n/g, '');
-      });
-
-      run.on('exit', function (code) {
-        assert.match(stdoutString, /Success:$/);
-        assert.equal(code, 0);
-        done();
-      });
-    });
-
-    it('`node-lambda run` exitCode is `0` (callback(null, "text"))', function (done) {
-      _generateHandlerFile('callback(null, "text");');
-
-      const run = spawn('node', [nodeLambdaPath, 'run', '--handler', '__test.handler']);
-      var stdoutString = '';
-      run.stdout.on('data', function (data) {
-        stdoutString += data.toString().replace(/\r|\n/g, '');
-      });
-
-      run.on('exit', function (code) {
-        assert.match(stdoutString, /Success:"text"$/);
-        assert.equal(code, 0);
-        done();
-      });
-    });
-
-    it('`node-lambda run` exitCode is `255` (callback(new Error("e")))', function (done) {
-      _generateHandlerFile('callback(new Error("e"));');
-
-      const run = spawn('node', [nodeLambdaPath, 'run', '--handler', '__test.handler']);
-      var stdoutString = '';
-      run.stdout.on('data', function (data) {
-        stdoutString += data.toString().replace(/\r|\n/g, '');
-      });
-
-      run.on('exit', function (code) {
-        assert.match(stdoutString, /Error: Error: e$/);
-        assert.equal(code, 255);
-        done();
       });
     });
   });

--- a/test/main.js
+++ b/test/main.js
@@ -9,6 +9,7 @@ var Hoek = require('hoek');
 var lambda = require(path.join(__dirname, '..', 'lib', 'main'));
 var zip = require('node-zip');
 var rimraf = require('rimraf');
+var spawn = require('child_process').spawn;
 
 var assert = chai.assert;
 
@@ -846,6 +847,84 @@ describe('node-lambda', function () {
           fs.readFileSync(boilerplateFile).toString(),
           targetFile
         );
+      });
+    });
+  });
+
+  describe('node-lambda run', function () {
+    const nodeLambdaPath = path.join('bin', 'node-lambda');
+    const _generateHandlerFile = function (callbackString) {
+      fs.writeFileSync(
+        '__test.js',
+        fs.readFileSync('index.js').toString()
+          .replace(/callback\(null\);/, callbackString)
+      );
+    };
+
+    before(function () {
+      // Restore default value
+      program.eventFile = 'event.json';
+      program.contextFile = 'context.json';
+
+      lambda.setup(program);
+    });
+
+    after(function () {
+      [
+        '.env',
+        'context.json',
+        'event.json',
+        'deploy.env',
+        'event_sources.json',
+        '__test.js'
+      ].forEach(function(file) {
+        fs.unlinkSync(file);
+      });
+    });
+
+    it('`node-lambda run` exitCode is `0` (callback(null))', function (done) {
+      const run = spawn(nodeLambdaPath, ['run']);
+      var stdoutString = '';
+      run.stdout.on('data', function (data) {
+        stdoutString += data.toString().replace(/\r|\n/g, '');
+      });
+
+      run.on('exit', function (code) {
+        assert.match(stdoutString, /Success:$/);
+        assert.equal(code, 0);
+        done();
+      });
+    });
+
+    it('`node-lambda run` exitCode is `0` (callback(null, "text"))', function (done) {
+      _generateHandlerFile('callback(null, "text");');
+
+      const run = spawn(nodeLambdaPath, ['run', '--handler', '__test.handler']);
+      var stdoutString = '';
+      run.stdout.on('data', function (data) {
+        stdoutString += data.toString().replace(/\r|\n/g, '');
+      });
+
+      run.on('exit', function (code) {
+        assert.match(stdoutString, /Success:"text"$/);
+        assert.equal(code, 0);
+        done();
+      });
+    });
+
+    it('`node-lambda run` exitCode is `255` (callback(new Error("e")))', function (done) {
+      _generateHandlerFile('callback(new Error("e"));');
+
+      const run = spawn(nodeLambdaPath, ['run', '--handler', '__test.handler']);
+      var stdoutString = '';
+      run.stdout.on('data', function (data) {
+        stdoutString += data.toString().replace(/\r|\n/g, '');
+      });
+
+      run.on('exit', function (code) {
+        assert.match(stdoutString, /Error: Error: e$/);
+        assert.equal(code, 255);
+        done();
       });
     });
   });

--- a/test/main.js
+++ b/test/main.js
@@ -883,7 +883,7 @@ describe('node-lambda', function () {
     });
 
     it('`node-lambda run` exitCode is `0` (callback(null))', function (done) {
-      const run = spawn(nodeLambdaPath, ['run']);
+      const run = spawn('node', [nodeLambdaPath, 'run']);
       var stdoutString = '';
       run.stdout.on('data', function (data) {
         stdoutString += data.toString().replace(/\r|\n/g, '');
@@ -899,7 +899,7 @@ describe('node-lambda', function () {
     it('`node-lambda run` exitCode is `0` (callback(null, "text"))', function (done) {
       _generateHandlerFile('callback(null, "text");');
 
-      const run = spawn(nodeLambdaPath, ['run', '--handler', '__test.handler']);
+      const run = spawn('node', [nodeLambdaPath, 'run', '--handler', '__test.handler']);
       var stdoutString = '';
       run.stdout.on('data', function (data) {
         stdoutString += data.toString().replace(/\r|\n/g, '');
@@ -915,7 +915,7 @@ describe('node-lambda', function () {
     it('`node-lambda run` exitCode is `255` (callback(new Error("e")))', function (done) {
       _generateHandlerFile('callback(new Error("e"));');
 
-      const run = spawn(nodeLambdaPath, ['run', '--handler', '__test.handler']);
+      const run = spawn('node', [nodeLambdaPath, 'run', '--handler', '__test.handler']);
       var stdoutString = '';
       run.stdout.on('data', function (data) {
         stdoutString += data.toString().replace(/\r|\n/g, '');

--- a/test/node-lambda.js
+++ b/test/node-lambda.js
@@ -18,9 +18,7 @@ describe('bin/node-lambda', () => {
       );
     };
 
-    before(() => {
-      execSync(`node ${nodeLambdaPath} setup`);
-    });
+    before(() => execSync(`node ${nodeLambdaPath} setup`));
 
     after(() => {
       [
@@ -30,51 +28,49 @@ describe('bin/node-lambda', () => {
         'deploy.env',
         'event_sources.json',
         '__test.js'
-      ].forEach(function(file) {
-        fs.unlinkSync(file);
-      });
+      ].forEach((file) => fs.unlinkSync(file));
     });
 
-    it('`node-lambda run` exitCode is `0` (callback(null))', function (done) {
+    it('`node-lambda run` exitCode is `0` (callback(null))', (done) => {
       const run = spawn('node', [nodeLambdaPath, 'run']);
       var stdoutString = '';
-      run.stdout.on('data', function (data) {
+      run.stdout.on('data', (data) => {
         stdoutString += data.toString().replace(/\r|\n/g, '');
       });
 
-      run.on('exit', function (code) {
+      run.on('exit', (code) => {
         assert.match(stdoutString, /Success:$/);
         assert.equal(code, 0);
         done();
       });
     });
 
-    it('`node-lambda run` exitCode is `0` (callback(null, "text"))', function (done) {
+    it('`node-lambda run` exitCode is `0` (callback(null, "text"))', (done) => {
       _generateHandlerFile('callback(null, "text");');
 
       const run = spawn('node', [nodeLambdaPath, 'run', '--handler', '__test.handler']);
       var stdoutString = '';
-      run.stdout.on('data', function (data) {
+      run.stdout.on('data', (data) => {
         stdoutString += data.toString().replace(/\r|\n/g, '');
       });
 
-      run.on('exit', function (code) {
+      run.on('exit', (code) => {
         assert.match(stdoutString, /Success:"text"$/);
         assert.equal(code, 0);
         done();
       });
     });
 
-    it('`node-lambda run` exitCode is `255` (callback(new Error("e")))', function (done) {
+    it('`node-lambda run` exitCode is `255` (callback(new Error("e")))', (done) => {
       _generateHandlerFile('callback(new Error("e"));');
 
       const run = spawn('node', [nodeLambdaPath, 'run', '--handler', '__test.handler']);
       var stdoutString = '';
-      run.stdout.on('data', function (data) {
+      run.stdout.on('data', (data) => {
         stdoutString += data.toString().replace(/\r|\n/g, '');
       });
 
-      run.on('exit', function (code) {
+      run.on('exit', (code) => {
         assert.match(stdoutString, /Error: Error: e$/);
         assert.equal(code, 255);
         done();

--- a/test/node-lambda.js
+++ b/test/node-lambda.js
@@ -5,7 +5,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const spawn = require('child_process').spawn;
 const execSync = require('child_process').execSync;
-const nodeLambdaPath = path.join('bin', 'node-lambda');
+const nodeLambdaPath = path.join(__dirname, '..', 'bin', 'node-lambda');
 
 // The reason for specifying the node command in this test is to support Windows.
 describe('bin/node-lambda', () => {

--- a/test/node-lambda.js
+++ b/test/node-lambda.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const assert = require('chai').assert;
+const path = require('path');
+const fs = require('fs-extra');
+const spawn = require('child_process').spawn;
+const execSync = require('child_process').execSync;
+const nodeLambdaPath = path.join('bin', 'node-lambda');
+
+// The reason for specifying the node command in this test is to support Windows.
+describe('bin/node-lambda', () => {
+  describe('node-lambda run', () => {
+    const _generateHandlerFile = (callbackString) => {
+      fs.writeFileSync(
+        '__test.js',
+        fs.readFileSync('index.js').toString()
+          .replace(/callback\(null\);/, callbackString)
+      );
+    };
+
+    before(() => {
+      execSync(`node ${nodeLambdaPath} setup`);
+    });
+
+    after(() => {
+      [
+        '.env',
+        'context.json',
+        'event.json',
+        'deploy.env',
+        'event_sources.json',
+        '__test.js'
+      ].forEach(function(file) {
+        fs.unlinkSync(file);
+      });
+    });
+
+    it('`node-lambda run` exitCode is `0` (callback(null))', function (done) {
+      const run = spawn('node', [nodeLambdaPath, 'run']);
+      var stdoutString = '';
+      run.stdout.on('data', function (data) {
+        stdoutString += data.toString().replace(/\r|\n/g, '');
+      });
+
+      run.on('exit', function (code) {
+        assert.match(stdoutString, /Success:$/);
+        assert.equal(code, 0);
+        done();
+      });
+    });
+
+    it('`node-lambda run` exitCode is `0` (callback(null, "text"))', function (done) {
+      _generateHandlerFile('callback(null, "text");');
+
+      const run = spawn('node', [nodeLambdaPath, 'run', '--handler', '__test.handler']);
+      var stdoutString = '';
+      run.stdout.on('data', function (data) {
+        stdoutString += data.toString().replace(/\r|\n/g, '');
+      });
+
+      run.on('exit', function (code) {
+        assert.match(stdoutString, /Success:"text"$/);
+        assert.equal(code, 0);
+        done();
+      });
+    });
+
+    it('`node-lambda run` exitCode is `255` (callback(new Error("e")))', function (done) {
+      _generateHandlerFile('callback(new Error("e"));');
+
+      const run = spawn('node', [nodeLambdaPath, 'run', '--handler', '__test.handler']);
+      var stdoutString = '';
+      run.stdout.on('data', function (data) {
+        stdoutString += data.toString().replace(/\r|\n/g, '');
+      });
+
+      run.on('exit', function (code) {
+        assert.match(stdoutString, /Error: Error: e$/);
+        assert.equal(code, 255);
+        done();
+      });
+    });
+  });
+});

--- a/test/schedule_events.js
+++ b/test/schedule_events.js
@@ -38,7 +38,7 @@ const mockResponse = {
 
 var schedule = null;
 
-describe('schedule_events', () => {
+describe('lib/schedule_events', () => {
   before(() => {
     aws.mock('CloudWatchEvents', 'putRule', (params, callback) => {
       callback(null, mockResponse.putRule);


### PR DESCRIPTION
- Fix not explicitly exit when `result` is present
    - Because Node.js 4.3 sometimes truncate on the way if the result size is large
    - #264
- Modify exitcode to positive integer
    - Because the value changes on Windows and Linux.
- Added `bin/node-lambda` test