### PR TITLE
Fix not specifying file name with test in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "mocha test/*.js"
+    "test": "mocha"
   },
   "bin": {
     "node-lambda": "./bin/node-lambda"


### PR DESCRIPTION
This makes it possible to test each file with `npm test FILE_NAME`.
If nothing is specified, `test/*.js` is targeted.