### PR TITLE
Remove `_rsync`

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -228,9 +228,9 @@ Lambda.prototype._eventSourceList = function (program) {
   return list
 }
 
-Lambda.prototype._fileCopy = function (program, src, dest, excludeNodeModules, callback) {
+Lambda.prototype._fileCopy = (program, src, dest, excludeNodeModules, callback) => {
   const srcAbsolutePath = path.resolve(src)
-  const excludes = (function () {
+  const excludes = (() => {
     return [
       '.git*',
       '*.swp',
@@ -246,7 +246,7 @@ Lambda.prototype._fileCopy = function (program, src, dest, excludeNodeModules, c
 
   // Formatting for `filter` of `fs.copy`
   const dirBlobs = []
-  const pattern = '{' + excludes.map(function (str) {
+  const pattern = '{' + excludes.map((str) => {
     if (str.charAt(str.length - 1) === path.sep) {
       str = str.substr(0, str.length - 1)
       dirBlobs.push(str)
@@ -261,13 +261,13 @@ Lambda.prototype._fileCopy = function (program, src, dest, excludeNodeModules, c
   }).join(',') + '}'
   const dirPatternRegExp = new RegExp(`(${dirBlobs.join('|')})$`)
 
-  fs.mkdirs(dest, function (err) {
+  fs.mkdirs(dest, (err) => {
     if (err) {
       return callback(err)
     }
     const options = {
       dereference: true, // same meaning as `-L` of `rsync` command
-      filter: function (src, dest) {
+      filter: (src, dest) => {
         if (!program.prebuiltDirectory && src === path.join(srcAbsolutePath, 'package.json')) {
           // include package.json unless prebuiltDirectory is set
           return true
@@ -523,7 +523,7 @@ Lambda.prototype._buildAndArchive = function (program, archiveCallback) {
   var codeDirectory = _this._codeDirectory()
   var lambdaSrcDirectory = program.sourceDirectory ? program.sourceDirectory.replace(/\/$/, '') : '.'
 
-  _this._cleanDirectory(codeDirectory, function (err) {
+  _this._cleanDirectory(codeDirectory, (err) => {
     if (err) {
       return archiveCallback(err)
     }
@@ -535,12 +535,12 @@ Lambda.prototype._buildAndArchive = function (program, archiveCallback) {
         return archiveCallback(err)
       }
       console.log('=> Running npm install --production')
-      _this._npmInstall(program, codeDirectory, function (err) {
+      _this._npmInstall(program, codeDirectory, (err) => {
         if (err) {
           return archiveCallback(err)
         }
 
-        _this._postInstallScript(program, codeDirectory, function (err) {
+        _this._postInstallScript(program, codeDirectory, (err) => {
           if (err) {
             return archiveCallback(err)
           }

--- a/lib/main.js
+++ b/lib/main.js
@@ -293,43 +293,6 @@ Lambda.prototype._fileCopy = function (program, src, dest, excludeNodeModules, c
   })
 }
 
-// `_rsync` will be replaced by` _fileCopy`.
-Lambda.prototype._rsync = function (program, src, dest, excludeNodeModules, callback) {
-  var excludes = ['.git*', '*.swp', '.editorconfig', '.lambda', 'deploy.env', '*.log', '/build/']
-  var excludeGlobs = []
-  if (program.excludeGlobs) {
-    excludeGlobs = program.excludeGlobs.split(' ')
-  }
-  var excludeArgs = excludeGlobs
-    .concat(excludes)
-    .concat(excludeNodeModules ? ['/node_modules'] : [])
-    .map(function (exclude) {
-      return '--exclude=' + exclude
-    }).join(' ')
-
-  fs.mkdirs(dest, function (err) {
-    if (err) {
-      return callback(err)
-    }
-
-    // include package.json unless prebuiltDirectory is set
-    var includeArgs = program.prebuiltDirectory ? '' : '--include /package.json '
-
-    // we need the extra / after src to make sure we are copying the content
-    // of the directory, not the directory itself.
-    exec('rsync -rL ' + includeArgs + excludeArgs + ' ' + src.trim() + '/ ' + dest, {
-      maxBuffer: maxBufferSize,
-      env: process.env
-    }, function (err) {
-      if (err) {
-        return callback(err)
-      }
-
-      return callback(null, true)
-    })
-  })
-}
-
 Lambda.prototype._npmInstall = (program, codeDirectory, callback) => {
   const dockerBaseOptions = [
     'run', '--rm', '-v', `${codeDirectory}:/var/task`,
@@ -532,15 +495,7 @@ Lambda.prototype._archivePrebuilt = function (program, archiveCallback) {
   var codeDirectory = this._codeDirectory()
   var _this = this
 
-  // It is switched to `_ rsync` by environment variable.
-  // (Used if there is a problem with `_ fileCopy`)
-  // If there is no problem even if deleting `_rsync`, this switching process is deleted
-  var copyFunction = '_fileCopy'
-  if (process.env.NODE_LAMBDA_COPY_FUNCTION === 'rsync') {
-    console.log('=> INFO: Use rsync for copy')
-    copyFunction = '_rsync'
-  }
-  this[copyFunction](program, program.prebuiltDirectory, codeDirectory, false, function (err) {
+  _this._fileCopy(program, program.prebuiltDirectory, codeDirectory, false, (err) => {
     if (err) {
       return archiveCallback(err)
     }
@@ -574,16 +529,8 @@ Lambda.prototype._buildAndArchive = function (program, archiveCallback) {
     }
     console.log('=> Moving files to temporary directory')
 
-    // It is switched to `_ rsync` by environment variable.
-    // (Used if there is a problem with `_ fileCopy`)
-    // If there is no problem even if deleting `_rsync`, this switching process is deleted
-    var copyFunction = '_fileCopy'
-    if (process.env.NODE_LAMBDA_COPY_FUNCTION === 'rsync') {
-      console.log('=> INFO: Use rsync for copy')
-      copyFunction = '_rsync'
-    }
     // Move files to tmp folder
-    _this[copyFunction](program, lambdaSrcDirectory, codeDirectory, true, function (err) {
+    _this._fileCopy(program, lambdaSrcDirectory, codeDirectory, true, (err) => {
       if (err) {
         return archiveCallback(err)
       }

--- a/lib/main.js
+++ b/lib/main.js
@@ -492,8 +492,8 @@ Lambda.prototype._archive = function (program, archiveCallback) {
 }
 
 Lambda.prototype._archivePrebuilt = function (program, archiveCallback) {
-  var codeDirectory = this._codeDirectory()
-  var _this = this
+  const codeDirectory = this._codeDirectory()
+  const _this = this
 
   _this._fileCopy(program, program.prebuiltDirectory, codeDirectory, false, (err) => {
     if (err) {
@@ -512,16 +512,16 @@ Lambda.prototype._buildAndArchive = function (program, archiveCallback) {
   }
 
   // Warn if not building on 64-bit linux
-  var arch = process.platform + '.' + process.arch
+  const arch = process.platform + '.' + process.arch
   if (arch !== 'linux.x64' && !program.dockerImage) {
     console.warn('Warning!!! You are building on a platform that is not 64-bit Linux (%s). ' +
       'If any of your Node dependencies include C-extensions, they may not work as expected in the ' +
       'Lambda environment.\n\n', arch)
   }
 
-  var _this = this
-  var codeDirectory = _this._codeDirectory()
-  var lambdaSrcDirectory = program.sourceDirectory ? program.sourceDirectory.replace(/\/$/, '') : '.'
+  const _this = this
+  const codeDirectory = _this._codeDirectory()
+  const lambdaSrcDirectory = program.sourceDirectory ? program.sourceDirectory.replace(/\/$/, '') : '.'
 
   _this._cleanDirectory(codeDirectory, (err) => {
     if (err) {

--- a/test/main.js
+++ b/test/main.js
@@ -268,7 +268,7 @@ describe('lib/main', function () {
   })
 
   describe('_fileCopy', () => {
-    before(function () {
+    before(() => {
       fs.mkdirSync('build')
       fs.mkdirsSync(path.join('__unittest', 'hoge'))
       fs.mkdirsSync(path.join('__unittest', 'fuga'))
@@ -276,32 +276,30 @@ describe('lib/main', function () {
       fs.writeFileSync(path.join('__unittest', 'hoge', 'package.json'))
       fs.writeFileSync('fuga')
     })
-    after(function () {
-      ['build', 'fuga', '__unittest'].forEach(function (path) {
+    after(() => {
+      ['build', 'fuga', '__unittest'].forEach((path) => {
         fs.removeSync(path)
       })
     })
 
-    beforeEach(function (done) {
-      lambda._cleanDirectory(codeDirectory, done)
-    })
+    beforeEach((done) => lambda._cleanDirectory(codeDirectory, done))
 
     it('_fileCopy an index.js as well as other files', (done) => {
       lambda._fileCopy(program, '.', codeDirectory, true, (err, result) => {
         assert.isNull(err)
         var contents = fs.readdirSync(codeDirectory);
-        ['index.js', 'package.json'].forEach(function (needle) {
+        ['index.js', 'package.json'].forEach((needle) => {
           assert.include(contents, needle, `Target: "${needle}"`)
         });
-        ['node_modules', 'build'].forEach(function (needle) {
+        ['node_modules', 'build'].forEach((needle) => {
           assert.notInclude(contents, needle, `Target: "${needle}"`)
         })
         done()
       })
     })
 
-    describe('when there are excluded files', function () {
-      beforeEach(function (done) {
+    describe('when there are excluded files', () => {
+      beforeEach((done) => {
         // *main* => lib/main.js
         // In case of specifying files under the directory with wildcards
         program.excludeGlobs = [
@@ -318,7 +316,7 @@ describe('lib/main', function () {
         lambda._fileCopy(program, '.', codeDirectory, true, (err, result) => {
           assert.isNull(err)
           var contents = fs.readdirSync(codeDirectory);
-          ['index.js', 'package.json'].forEach(function (needle) {
+          ['index.js', 'package.json'].forEach((needle) => {
             assert.include(contents, needle, `Target: "${needle}"`)
           })
           done()
@@ -329,11 +327,11 @@ describe('lib/main', function () {
         lambda._fileCopy(program, '.', codeDirectory, true, (err, result) => {
           assert.isNull(err)
           var contents = fs.readdirSync(codeDirectory);
-          ['__unittest', 'fuga'].forEach(function (needle) {
+          ['__unittest', 'fuga'].forEach((needle) => {
             assert.include(contents, needle, `Target: "${needle}"`)
           });
 
-          ['node-lambda.png', 'test'].forEach(function (needle) {
+          ['node-lambda.png', 'test'].forEach((needle) => {
             assert.notInclude(contents, needle, `Target: "${needle}"`)
           })
 
@@ -352,7 +350,7 @@ describe('lib/main', function () {
 
       it('_fileCopy should not exclude package.json, even when excluded by excludeGlobs', (done) => {
         program.excludeGlobs = '*.json'
-        lambda[funcName](program, '.', codeDirectory, true, function (err, result) {
+        lambda._fileCopy(program, '.', codeDirectory, true, (err, result) => {
           assert.isNull(err)
           var contents = fs.readdirSync(codeDirectory)
           assert.include(contents, 'package.json')
@@ -362,9 +360,7 @@ describe('lib/main', function () {
 
       it('_fileCopy should not include package.json when --prebuiltDirectory is set', (done) => {
         var buildDir = '.build_' + Date.now()
-        after(function () {
-          fs.removeSync(buildDir)
-        })
+        after(() => fs.removeSync(buildDir))
 
         fs.mkdirSync(buildDir)
         fs.writeFileSync(path.join(buildDir, 'testa'))

--- a/test/main.js
+++ b/test/main.js
@@ -267,7 +267,7 @@ describe('lib/main', function () {
     })
   })
 
-  function rsyncTests (funcName) {
+  describe('_fileCopy', () => {
     before(function () {
       fs.mkdirSync('build')
       fs.mkdirsSync(path.join('__unittest', 'hoge'))
@@ -286,8 +286,8 @@ describe('lib/main', function () {
       lambda._cleanDirectory(codeDirectory, done)
     })
 
-    it(funcName + ' an index.js as well as other files', function (done) {
-      lambda[funcName](program, '.', codeDirectory, true, function (err, result) {
+    it('_fileCopy an index.js as well as other files', (done) => {
+      lambda._fileCopy(program, '.', codeDirectory, true, (err, result) => {
         assert.isNull(err)
         var contents = fs.readdirSync(codeDirectory);
         ['index.js', 'package.json'].forEach(function (needle) {
@@ -314,8 +314,8 @@ describe('lib/main', function () {
         done()
       })
 
-      it(funcName + ' an index.js as well as other files', function (done) {
-        lambda[funcName](program, '.', codeDirectory, true, function (err, result) {
+      it('_fileCopy an index.js as well as other files', (done) => {
+        lambda._fileCopy(program, '.', codeDirectory, true, (err, result) => {
           assert.isNull(err)
           var contents = fs.readdirSync(codeDirectory);
           ['index.js', 'package.json'].forEach(function (needle) {
@@ -325,8 +325,8 @@ describe('lib/main', function () {
         })
       })
 
-      it(funcName + ' excludes files matching excludeGlobs', function (done) {
-        lambda[funcName](program, '.', codeDirectory, true, function (err, result) {
+      it('_fileCopy excludes files matching excludeGlobs', (done) => {
+        lambda._fileCopy(program, '.', codeDirectory, true, (err, result) => {
           assert.isNull(err)
           var contents = fs.readdirSync(codeDirectory);
           ['__unittest', 'fuga'].forEach(function (needle) {
@@ -350,7 +350,7 @@ describe('lib/main', function () {
         })
       })
 
-      it(funcName + ' should not exclude package.json, even when excluded by excludeGlobs', function (done) {
+      it('_fileCopy should not exclude package.json, even when excluded by excludeGlobs', (done) => {
         program.excludeGlobs = '*.json'
         lambda[funcName](program, '.', codeDirectory, true, function (err, result) {
           assert.isNull(err)
@@ -360,7 +360,7 @@ describe('lib/main', function () {
         })
       })
 
-      it(funcName + ' should not include package.json when --prebuiltDirectory is set', function (done) {
+      it('_fileCopy should not include package.json when --prebuiltDirectory is set', (done) => {
         var buildDir = '.build_' + Date.now()
         after(function () {
           fs.removeSync(buildDir)
@@ -372,7 +372,7 @@ describe('lib/main', function () {
 
         program.excludeGlobs = '*.json'
         program.prebuiltDirectory = buildDir
-        lambda[funcName](program, buildDir, codeDirectory, true, function (err, result) {
+        lambda._fileCopy(program, buildDir, codeDirectory, true, (err, result) => {
           assert.isNull(err)
           var contents = fs.readdirSync(codeDirectory)
           assert.notInclude(contents, 'package.json', 'Target: "packages.json"')
@@ -381,14 +381,7 @@ describe('lib/main', function () {
         })
       })
     })
-  }
-
-  describe('_fileCopy', function () { rsyncTests('_fileCopy') })
-  if (process.platform === 'win32') {
-    it('For Windows, `_rsync` tests pending')
-  } else {
-    describe('_rsync', function () { rsyncTests('_rsync') })
-  }
+  })
 
   describe('_npmInstall', () => {
     beforeEach((done) => {

--- a/test/main.js
+++ b/test/main.js
@@ -287,7 +287,7 @@ describe('lib/main', function () {
     it('_fileCopy an index.js as well as other files', (done) => {
       lambda._fileCopy(program, '.', codeDirectory, true, (err, result) => {
         assert.isNull(err)
-        var contents = fs.readdirSync(codeDirectory);
+        const contents = fs.readdirSync(codeDirectory);
         ['index.js', 'package.json'].forEach((needle) => {
           assert.include(contents, needle, `Target: "${needle}"`)
         });
@@ -315,7 +315,7 @@ describe('lib/main', function () {
       it('_fileCopy an index.js as well as other files', (done) => {
         lambda._fileCopy(program, '.', codeDirectory, true, (err, result) => {
           assert.isNull(err)
-          var contents = fs.readdirSync(codeDirectory);
+          const contents = fs.readdirSync(codeDirectory);
           ['index.js', 'package.json'].forEach((needle) => {
             assert.include(contents, needle, `Target: "${needle}"`)
           })
@@ -326,7 +326,7 @@ describe('lib/main', function () {
       it('_fileCopy excludes files matching excludeGlobs', (done) => {
         lambda._fileCopy(program, '.', codeDirectory, true, (err, result) => {
           assert.isNull(err)
-          var contents = fs.readdirSync(codeDirectory);
+          let contents = fs.readdirSync(codeDirectory);
           ['__unittest', 'fuga'].forEach((needle) => {
             assert.include(contents, needle, `Target: "${needle}"`)
           });
@@ -352,14 +352,14 @@ describe('lib/main', function () {
         program.excludeGlobs = '*.json'
         lambda._fileCopy(program, '.', codeDirectory, true, (err, result) => {
           assert.isNull(err)
-          var contents = fs.readdirSync(codeDirectory)
+          const contents = fs.readdirSync(codeDirectory)
           assert.include(contents, 'package.json')
           done()
         })
       })
 
       it('_fileCopy should not include package.json when --prebuiltDirectory is set', (done) => {
-        var buildDir = '.build_' + Date.now()
+        const buildDir = '.build_' + Date.now()
         after(() => fs.removeSync(buildDir))
 
         fs.mkdirSync(buildDir)
@@ -370,7 +370,7 @@ describe('lib/main', function () {
         program.prebuiltDirectory = buildDir
         lambda._fileCopy(program, buildDir, codeDirectory, true, (err, result) => {
           assert.isNull(err)
-          var contents = fs.readdirSync(codeDirectory)
+          const contents = fs.readdirSync(codeDirectory)
           assert.notInclude(contents, 'package.json', 'Target: "packages.json"')
           assert.include(contents, 'testa', 'Target: "testa"')
           done()


### PR DESCRIPTION
Even if there is a bug in `_fileCopy`, we left it to be usable, but since it seems that there is no serious problem with `_fileCopy`, removed it.