### PR TITLE
Fix to deprecated the `configFile` option in the `pacakage` command

### DIFF
--- a/bin/node-lambda
+++ b/bin/node-lambda
@@ -107,8 +107,7 @@ program
     AWS_ENVIRONMENT)
   .option('-x, --excludeGlobs [' + EXCLUDE_GLOBS + ']',
     'Space-separated glob pattern(s) for additional exclude files (e.g. "event.json dotenv.sample")', EXCLUDE_GLOBS)
-  .option('-f, --configFile [' + CONFIG_FILE + ']',
-    'Path to file holding secret environment variables (e.g. "deploy.env")', CONFIG_FILE)
+  .option('-f, --configFile [' + CONFIG_FILE + ']', '!!! Deprecated option in package command !!!', CONFIG_FILE)
   .option('-D, --prebuiltDirectory [' + PREBUILT_DIRECTORY + ']', 'Prebuilt directory', PREBUILT_DIRECTORY)
   .action((prg) => lambda.package(prg))
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -689,6 +689,9 @@ Lambda.prototype._updateScheduleEvents = (scheduleEvents, functionArn, scheduleL
 }
 
 Lambda.prototype.package = function (program) {
+  if (program.configFile) {
+    console.warn('[Warning] -f, --configFile option of the `package` command is deprecated.')
+  }
   const _this = this
   if (!program.packageDirectory) {
     throw new Error('packageDirectory not specified!')


### PR DESCRIPTION
Even if you specify it in the current specification, nothing has any effect.
Therefore, I thought that it might be good to abolish it, but what do you think?

Since sudden deletion has a big influence, we have issued a warning once.

Relation: #246