### PR TITLE
bump to 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,3 +240,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Update package-lock.json [#328](https://github.com/motdotla/node-lambda/pull/328)
 - Remove `_rsync` [#329](https://github.com/motdotla/node-lambda/pull/329)
 - Bugfixed that mode of file changes when zip is created [#335](https://github.com/motdotla/node-lambda/pull/335)
+
+## [0.11.2] - 2017-07-05
+### Features
+- Fix to deprecated the `configFile` option in the `pacakage` command [#344](https://github.com/motdotla/node-lambda/pull/344)
+
+### Bugfixes
+- Fix to set boolean in params.Publish [#346](https://github.com/motdotla/node-lambda/pull/346)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lambda",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Command line tool for locally running and remotely deploying your node.js applications to Amazon Lambda.",
   "main": "lib/main.js",
   "directories": {

--- a/test/main.js
+++ b/test/main.js
@@ -126,7 +126,7 @@ describe('lib/main', function () {
   })
 
   it('version should be set', () => {
-    assert.equal(lambda.version, '0.11.1')
+    assert.equal(lambda.version, '0.11.2')
   })
 
   describe('_codeDirectory', () => {


### PR DESCRIPTION
## [0.11.2] - 2017-07-05
### Features
- Fix to deprecated the `configFile` option in the `pacakage` command [#344](https://github.com/motdotla/node-lambda/pull/344)

### Bugfixes
- Fix to set boolean in params.Publish [#346](https://github.com/motdotla/node-lambda/pull/346)
