### PR TITLE
bump to 0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,3 +247,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Bugfixes
 - Fix to set boolean in params.Publish [#346](https://github.com/motdotla/node-lambda/pull/346)
+
+## [0.11.3] - 2017-07-07
+### Features
+- Fix symlink at zip [#348](https://github.com/motdotla/node-lambda/pull/348)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lambda",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Command line tool for locally running and remotely deploying your node.js applications to Amazon Lambda.",
   "main": "lib/main.js",
   "directories": {

--- a/test/main.js
+++ b/test/main.js
@@ -126,7 +126,7 @@ describe('lib/main', function () {
   })
 
   it('version should be set', () => {
-    assert.equal(lambda.version, '0.11.2')
+    assert.equal(lambda.version, '0.11.3')
   })
 
   describe('_codeDirectory', () => {


### PR DESCRIPTION
## [0.11.3] - 2017-07-07
### Features
- Fix symlink at zip [#348](https://github.com/motdotla/node-lambda/pull/348)
