### PR TITLE
Add the ability to set KMSKeyArn to a Lambda function

### DIFF
--- a/bin/node-lambda
+++ b/bin/node-lambda
@@ -43,7 +43,7 @@ const SRC_DIRECTORY = process.env.SRC_DIRECTORY || ''
 const DEPLOY_TIMEOUT = process.env.DEPLOY_TIMEOUT || 120000
 const DOCKER_IMAGE = process.env.DOCKER_IMAGE || ''
 const DEPLOY_ZIPFILE = process.env.DEPLOY_ZIPFILE || ''
-const AWS_KMS_KEY_ARN = process.env.AWS_KMS_KEY_ARN
+const AWS_KMS_KEY_ARN = process.env.AWS_KMS_KEY_ARN || ''
 const AWS_DLQ_TARGET_ARN = (() => {
   // You can clear the setting by passing an empty string
   // when executing updateFunctionConfiguration

--- a/bin/node-lambda
+++ b/bin/node-lambda
@@ -43,6 +43,7 @@ const SRC_DIRECTORY = process.env.SRC_DIRECTORY || ''
 const DEPLOY_TIMEOUT = process.env.DEPLOY_TIMEOUT || 120000
 const DOCKER_IMAGE = process.env.DOCKER_IMAGE || ''
 const DEPLOY_ZIPFILE = process.env.DEPLOY_ZIPFILE || ''
+const AWS_KMS_KEY_ARN = process.env.AWS_KMS_KEY_ARN
 const AWS_DLQ_TARGET_ARN = (() => {
   // You can clear the setting by passing an empty string
   // when executing updateFunctionConfiguration
@@ -76,6 +77,7 @@ program
   .option('-b, --vpcSubnets [' + AWS_VPC_SUBNETS + ']', 'Lambda Function VPC Subnets', AWS_VPC_SUBNETS)
   .option('-g, --vpcSecurityGroups [' + AWS_VPC_SECURITY_GROUPS + ']', 'Lambda VPC Security Group',
     AWS_VPC_SECURITY_GROUPS)
+  .option('-K, --kmsKeyArn [' + AWS_KMS_KEY_ARN + ']', 'Lambda KMS Key ARN', AWS_KMS_KEY_ARN)
   .option('-Q, --deadLetterConfigTargetArn [' + AWS_DLQ_TARGET_ARN + ']', 'Lambda DLQ resource',
     AWS_DLQ_TARGET_ARN)
   .option('-T, --tracingConfig [' + AWS_TRACING_CONFIG + ']', 'Lambda tracing settings',

--- a/lib/main.js
+++ b/lib/main.js
@@ -176,6 +176,7 @@ Lambda.prototype._params = (program, buffer) => {
     Environment: {
       Variables: null
     },
+    KMSKeyArn: program.kmsKeyArn,
     DeadLetterConfig: {
       TargetArn: null
     },
@@ -200,9 +201,6 @@ Lambda.prototype._params = (program, buffer) => {
     params.Environment = {
       Variables: config
     }
-  }
-  if (program.kmsKeyArn !== undefined) {
-    params.KMSKeyArn = program.kmsKeyArn
   }
   if (program.deadLetterConfigTargetArn !== undefined) {
     params.DeadLetterConfig = {

--- a/lib/main.js
+++ b/lib/main.js
@@ -201,6 +201,9 @@ Lambda.prototype._params = (program, buffer) => {
       Variables: config
     }
   }
+  if (program.kmsKeyArn !== undefined) {
+    params.KMSKeyArn = program.kmsKeyArn
+  }
   if (program.deadLetterConfigTargetArn !== undefined) {
     params.DeadLetterConfig = {
       TargetArn: program.deadLetterConfigTargetArn
@@ -473,6 +476,7 @@ Lambda.prototype._uploadExisting = (lambda, params) => {
         'Runtime': params.Runtime,
         'VpcConfig': params.VpcConfig,
         'Environment': params.Environment,
+        'KMSKeyArn': params.KMSKeyArn,
         'DeadLetterConfig': params.DeadLetterConfig,
         'TracingConfig': params.TracingConfig
       }, (err, data) => {

--- a/test/main.js
+++ b/test/main.js
@@ -196,6 +196,19 @@ describe('lib/main', function () {
       assert.equal(Object.keys(params.VpcConfig.SecurityGroupIds).length, 0)
     })
 
+    it('appends KMSKeyArn to params when KMS params set', () => {
+      ['', 'arn:aws:kms:test'].forEach((v) => {
+        program.kmsKeyArn = v
+        const params = lambda._params(program)
+        assert.equal(params.KMSKeyArn, v, v)
+      })
+    })
+
+    it('does not append KMSKeyArn when params are not set', () => {
+      const params = lambda._params(program)
+      assert.isUndefined(params.KMSKeyArn)
+    })
+
     it('appends DeadLetterConfig to params when DLQ params set', () => {
       ['', 'arn:aws:sqs:test'].forEach((v) => {
         program.deadLetterConfigTargetArn = v


### PR DESCRIPTION
The AWS SDK has the ability to set the KMSKeyArn when creating a Lambda function.
https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html

This PR adds the ability to set the KMSKeyArn. By default the value is not included in the params.