### PR TITLE
Added the ability to set constants when scheduling a Lambda function Cloudwatch event.

### DIFF
--- a/lib/event_sources.json.example
+++ b/lib/event_sources.json.example
@@ -11,7 +11,12 @@
     {
       "ScheduleName": "node-lambda-test-schedule",
       "ScheduleState": "ENABLED",
-      "ScheduleExpression": "rate(1 hour)"
+      "ScheduleExpression": "rate(1 hour)",
+      "Input":
+        {
+          "key": "value",
+          "key2": "value"
+        } 
     }
   ]
 }

--- a/lib/schedule_events.js
+++ b/lib/schedule_events.js
@@ -71,7 +71,8 @@ class ScheduleEvents {
       Rule: params.ScheduleName,
       Targets: [{
         Arn: params.FunctionArn,
-        Id: this._functionName(params)
+        Id: this._functionName(params),
+        Input: JSON.stringify(params.Input)
       }]
     }
   }


### PR DESCRIPTION
I needed the ability to pass variables to a Lambda function from a Cloudwatch event so that depending upon when the event was triggered would dictate which path the code takes.