### PR TITLE
Add invalidation of log output to make the test result easier to read

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -520,14 +520,18 @@ describe('lib/main', function () {
     })
 
     it('should not throw any errors if no script', () => {
+      disableLog()
       return lambda._postInstallScript(program, codeDirectory).then((dummy) => {
+        enableLog()
         assert.isUndefined(dummy)
       })
     })
 
     it('should throw any errors if script fails', () => {
       fs.writeFileSync(postInstallScriptPath, '___fails___')
+      disableLog()
       return lambda._postInstallScript(program, codeDirectory).catch((err) => {
+        enableLog()
         assert.instanceOf(err, Error)
         assert.match(err.message, /^Error: Command failed:/)
       })
@@ -573,7 +577,9 @@ describe('lib/main', function () {
     it('Compress the file. `index.js` and `bin/node-lambda` are included and the permission is also preserved.', function () {
       _timeout({ this: this, sec: 30 }) // give it time to zip
 
+      disableLog()
       return lambda._zip(program, codeDirectory).then((data) => {
+        enableLog()
         const archive = new Zip(data)
         assert.include(archive.files['index.js'].name, 'index.js')
         assert.include(archive.files['bin/node-lambda'].name, 'bin/node-lambda')
@@ -607,7 +613,9 @@ describe('lib/main', function () {
     it('installs and zips with an index.js file and node_modules/aws-sdk (It is also a test of `_buildAndArchive`)', function () {
       _timeout({ this: this, sec: 30 }) // give it time to zip
 
+      disableLog()
       return lambda._archive(program).then((data) => {
+        enableLog()
         const archive = new Zip(data)
         const contents = Object.keys(archive.files).map((k) => {
           return archive.files[k].name.toString()
@@ -630,7 +638,9 @@ describe('lib/main', function () {
       fs.writeFileSync(path.join(buildDir, 'd', 'testb'), '...')
 
       program.prebuiltDirectory = buildDir
+      disableLog()
       return lambda._archive(program).then((data) => {
+        enableLog()
         const archive = new Zip(data)
         const contents = Object.keys(archive.files).map((k) => {
           return archive.files[k].name.toString()
@@ -652,7 +662,9 @@ describe('lib/main', function () {
     before(function () {
       _timeout({ this: this, sec: 30 }) // give it time to zip
 
+      disableLog()
       return lambda._zip(program, codeDirectory).then((data) => {
+        enableLog()
         bufferExpected = data
         fs.writeFileSync(testZipFile, data)
       })
@@ -692,7 +704,9 @@ describe('lib/main', function () {
         const filePath = path.join(path.resolve('/aaaa'), 'bbbb')
         const _program = Object.assign({ deployZipfile: filePath }, program)
         _timeout({ this: this, sec: 30 }) // give it time to zip
+        disableLog()
         return lambda._archive(_program).then((data) => {
+          enableLog()
           // same test as "installs and zips with an index.js file and node_modules/aws-sdk"
           const archive = new Zip(data)
           const contents = Object.keys(archive.files).map((k) => {
@@ -746,7 +760,9 @@ describe('lib/main', function () {
     })
 
     it('should create sample files', () => {
+      disableLog()
       lambda.setup(program)
+      enableLog()
 
       const libPath = path.join(__dirname, '..', 'lib')
       targetFiles.forEach((targetFile) => {
@@ -1049,7 +1065,9 @@ describe('lib/main', function () {
       program.eventFile = 'newEvent.json'
       program.contextFile = 'newContext.json'
 
+      disableLog()
       lambda.setup(program)
+      enableLog()
 
       assert.equal(fs.readFileSync('newContext.json').toString(), '{"FOO"="bar"\n"BAZ"="bing"\n}')
       assert.equal(fs.readFileSync('newEvent.json').toString(), '{"FOO"="bar"}')

--- a/test/main.js
+++ b/test/main.js
@@ -113,6 +113,18 @@ const _awsRestore = () => {
   awsMock.restore('Lambda')
 }
 
+const disableLog = () => {
+  ['log', 'warn', 'info'].forEach((f) => {
+    console[f] = () => {}
+  })
+}
+
+const enableLog = () => {
+  ['log', 'warn', 'info'].forEach((f) => {
+    if (String(console[f]) === '() => {}') delete console[f]
+  })
+}
+
 /* global before, after, beforeEach, afterEach, describe, it */
 describe('lib/main', function () {
   if (process.platform === 'win32') {

--- a/test/main.js
+++ b/test/main.js
@@ -527,9 +527,7 @@ describe('lib/main', function () {
 
     it('should throw any errors if script fails', () => {
       fs.writeFileSync(postInstallScriptPath, '___fails___')
-      return lambda._postInstallScript(program, codeDirectory).then((dummy) => {
-        assert.isUndefined(dummy)
-      }).catch((err) => {
+      return lambda._postInstallScript(program, codeDirectory).catch((err) => {
         assert.instanceOf(err, Error)
         assert.match(err.message, /^Error: Command failed:/)
       })


### PR DESCRIPTION
I would be pleased if you could teach us if there is a better way to disable logging.