### PR TITLE
Fix commandline version option

### DIFF
--- a/bin/node-lambda
+++ b/bin/node-lambda
@@ -57,7 +57,6 @@ const PROXY = process.env.PROXY || process.env.http_proxy || ''
 
 program
   .command('deploy')
-  .version(lambda.version)
   .description('Deploy your application to Amazon Lambda')
   .option('-e, --environment [' + AWS_ENVIRONMENT + ']', 'Choose environment {dev, staging, production}',
     AWS_ENVIRONMENT)
@@ -135,7 +134,9 @@ program
   .option('-x, --contextFile [' + CONTEXT_FILE + ']', 'Context JSON File', CONTEXT_FILE)
   .action((prg) => lambda.setup(prg))
 
-program.parse(process.argv)
+program
+  .version(lambda.version)
+  .parse(process.argv)
 
 if (!process.argv.slice(2).length) {
   program.outputHelp()

--- a/test/node-lambda.js
+++ b/test/node-lambda.js
@@ -198,4 +198,12 @@ describe('bin/node-lambda', () => {
       })
     })
   })
+
+  describe('node-lambda --version', () => {
+    const packageJson = require(path.join(__dirname, '..', 'package.json'))
+    it('The current version is displayed', () => {
+      const ret = execSync(`${nodeLambdaPath} --version`)
+      assert.equal(ret.toString().trim(), packageJson.version)
+    })
+  })
 })

--- a/test/node-lambda.js
+++ b/test/node-lambda.js
@@ -202,7 +202,7 @@ describe('bin/node-lambda', () => {
   describe('node-lambda --version', () => {
     const packageJson = require(path.join(__dirname, '..', 'package.json'))
     it('The current version is displayed', () => {
-      const ret = execSync(`${nodeLambdaPath} --version`)
+      const ret = execSync(`node ${nodeLambdaPath} --version`)
       assert.equal(ret.toString().trim(), packageJson.version)
     })
   })


### PR DESCRIPTION
Version is displayed with the following command.
```
% node-lambda --version
0.11.3
```

It was an error before modification.
```
% node-lambda --version

  error: unknown option `--version'

```