### PR TITLE
Change: Ensure dotenv.load called before AWS load

### DIFF
--- a/bin/node-lambda
+++ b/bin/node-lambda
@@ -4,14 +4,15 @@
 
 const path = require('path')
 const dotenv = require('dotenv')
+
+dotenv.load()
+
 const lambda = require(path.join(__dirname, '..', 'lib', 'main.js'))
 const program = require('commander')
 const fs = require('fs')
 const packageJson = fs.existsSync(path.join(process.cwd(), 'package.json'))
   ? require(path.join(process.cwd(), 'package.json')) : {}
 const packageJsonName = packageJson.name || 'UnnamedFunction'
-
-dotenv.load()
 
 const AWS_ENVIRONMENT = process.env.AWS_ENVIRONMENT || ''
 const CONFIG_FILE = process.env.CONFIG_FILE || ''


### PR DESCRIPTION
This PR simply changes the the place `dotenv.load` is called to a few lines earlier, *before* requiring `aws-sdk`. This means the contents of one's `.env` is loaded into `process.env` before anything in AWS-SDK executes. This resolves an issue we've seen where aws-sdk seems to use *globally* set AWS creds instead of those in `./.env`. [This seems to be a source of frustration for others.](https://github.com/aws/aws-sdk-js/issues/1276) The issue becomes apparent when one attempts to use `node-lambda` as a dev dependency (rather than, as instructed, globally installed) in an app with other aws-sdk dependencies. 

This new placement of `dotenv.load` does not seem to have any effect on tests. Also `dotenv` does not seem to rely on side-effects of any code executed before it. So I don't see any reason `dotenv.load` should *not* be called in this new position (apart from this being an odd place to fix an aws-sdk quirk).