### PR TITLE
Use stable node, at npm release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ node_js:
 jobs:
   include:
     - stage: npm release
-      node_js: "7"
+      node_js: node
       script: echo "Deploying to npm ..."
       deploy:
         provider: npm


### PR DESCRIPTION
If "node" is set, latest stable Node.js release will be used.