### PR TITLE
Added the ability to set constants when scheduling a Lambda function Cloudwatch event.

### DIFF
--- a/lib/event_sources.json.example
+++ b/lib/event_sources.json.example
@@ -14,7 +14,7 @@
       "ScheduleExpression": "rate(1 hour)",
       "Input":
         {
-          "key": "value",
+          "key1": "value",
           "key2": "value"
         }
     }

--- a/lib/event_sources.json.example
+++ b/lib/event_sources.json.example
@@ -11,7 +11,12 @@
     {
       "ScheduleName": "node-lambda-test-schedule",
       "ScheduleState": "ENABLED",
-      "ScheduleExpression": "rate(1 hour)"
+      "ScheduleExpression": "rate(1 hour)",
+      "Input":
+        {
+          "key": "value",
+          "key2": "value"
+        } 
     }
   ]
 }

--- a/lib/event_sources.json.example
+++ b/lib/event_sources.json.example
@@ -16,7 +16,7 @@
         {
           "key": "value",
           "key2": "value"
-        } 
+        }
     }
   ]
 }

--- a/lib/schedule_events.js
+++ b/lib/schedule_events.js
@@ -71,7 +71,8 @@ class ScheduleEvents {
       Rule: params.ScheduleName,
       Targets: [{
         Arn: params.FunctionArn,
-        Id: this._functionName(params)
+        Id: this._functionName(params),
+        Input: JSON.stringify(params.Input)
       }]
     }
   }

--- a/lib/schedule_events.js
+++ b/lib/schedule_events.js
@@ -72,7 +72,7 @@ class ScheduleEvents {
       Targets: [{
         Arn: params.FunctionArn,
         Id: this._functionName(params),
-        Input: JSON.stringify(params.Input)
+        Input: params.hasOwnProperty('Input') ? JSON.stringify(params.Input) : ''
       }]
     }
   }

--- a/test/main.js
+++ b/test/main.js
@@ -814,7 +814,11 @@ describe('lib/main', function () {
             ScheduleEvents: [{
               ScheduleName: 'node-lambda-test-schedule',
               ScheduleState: 'ENABLED',
-              ScheduleExpression: 'rate(1 hour)'
+              ScheduleExpression: 'rate(1 hour)',
+              Input: {
+                key1: 'value',
+                key2: 'value'
+              }
             }]
           }
           assert.deepEqual(lambda._eventSourceList(program), expected)

--- a/test/schedule_events.js
+++ b/test/schedule_events.js
@@ -121,15 +121,31 @@ describe('lib/schedule_events', () => {
   })
 
   describe('_putTargetsParams', () => {
-    it('correct value', () => {
+    it('correct value (No "Input" setting)', () => {
       const expected = {
         Rule: 'node-lambda-test-schedule',
         Targets: [{
           Arn: 'arn:aws:lambda:us-west-2:XXX:function:node-lambda-test-function',
-          Id: 'node-lambda-test-function'
+          Id: 'node-lambda-test-function',
+          Input: ''
         }]
       }
       assert.deepEqual(schedule._putTargetsParams(params), expected)
+    })
+
+    it('correct value ("Input" setting)', () => {
+      const expected = {
+        Rule: 'node-lambda-test-schedule',
+        Targets: [{
+          Arn: 'arn:aws:lambda:us-west-2:XXX:function:node-lambda-test-function',
+          Id: 'node-lambda-test-function',
+          Input: '{"key":"value"}'
+        }]
+      }
+      assert.deepEqual(
+        schedule._putTargetsParams(Object.assign({Input: {key: 'value'}}, params)),
+        expected
+      )
     })
   })
 


### PR DESCRIPTION
I fixed it because the #364 was not updated for a long time.