### PR TITLE
Set docker run working directory so npm install works

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -317,7 +317,7 @@ so you can easily test run multiple events.
 
   _npmInstall (program, codeDirectory) {
     const dockerBaseOptions = [
-      'run', '--rm', '-v', `${codeDirectory}:/var/task`,
+      'run', '--rm', '-v', `${codeDirectory}:/var/task`, '-w', '/var/task',
       program.dockerImage,
       'npm', '-s', 'install', '--production'
     ]


### PR DESCRIPTION
npm install fails when deploying or packaging using a docker container because it is not being run in the correct container directory.

Adding the '-w /var/task' option to the docker run command fixes this.