### PR TITLE
Change short option of `--tracingConfig` to `-c`

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Options:
   -g, --vpcSecurityGroups []          Lambda VPC Security Group
   -K, --kmsKeyArn []                  Lambda KMS Key ARN
   -Q, --deadLetterConfigTargetArn []  Lambda DLQ resource
-  -T, --tracingConfig []              Lambda tracing settings
+  -c, --tracingConfig []              Lambda tracing settings
   -R, --retentionInDays []            CloudWatchLogs retentionInDays settings
   -A, --packageDirectory [build]      Local Package Directory
   -G, --sourceDirectory []            Path to lambda source Directory (e.g. "./some-lambda")

--- a/bin/node-lambda
+++ b/bin/node-lambda
@@ -82,7 +82,7 @@ program
   .option('-K, --kmsKeyArn [' + AWS_KMS_KEY_ARN + ']', 'Lambda KMS Key ARN', AWS_KMS_KEY_ARN)
   .option('-Q, --deadLetterConfigTargetArn [' + AWS_DLQ_TARGET_ARN + ']', 'Lambda DLQ resource',
     AWS_DLQ_TARGET_ARN)
-  .option('-T, --tracingConfig [' + AWS_TRACING_CONFIG + ']', 'Lambda tracing settings',
+  .option('-c, --tracingConfig [' + AWS_TRACING_CONFIG + ']', 'Lambda tracing settings',
     AWS_TRACING_CONFIG)
   .option('-R, --retentionInDays [' + AWS_LOGS_RETENTION_IN_DAYS + ']', 'CloudWatchLogs retentionInDays settings',
     AWS_LOGS_RETENTION_IN_DAYS)

--- a/test/node-lambda.js
+++ b/test/node-lambda.js
@@ -246,6 +246,37 @@ describe('bin/node-lambda', () => {
     })
   })
 
+  describe('node-lambda duplicate check of short option', () => {
+    const duplicateCheckTestFunc = (type, done) => {
+      const cmd = spawn('node', [nodeLambdaPath, type, '-h'])
+      let stdoutString = ''
+      cmd.stdout.on('data', (data) => {
+        stdoutString += data.toString()
+      })
+
+      cmd.on('exit', (code) => {
+        assert.equal(code, 0)
+
+        const shortOptions = stdoutString.split('\n').filter(line => {
+          return line.match(/^\s+-/)
+        }).map(line => {
+          return line.split(/\s+/)[1]
+        })
+        const uniqueShortOptions = shortOptions.filter((option, index, array) => {
+          return array.indexOf(option) === index
+        })
+        assert.equal(shortOptions.length, uniqueShortOptions.length)
+        done()
+      })
+    }
+
+    ['deploy', 'run', 'setup'].forEach(type => {
+      it(`cmd:${type}`, (done) => {
+        duplicateCheckTestFunc(type, done)
+      })
+    })
+  })
+
   describe('node-lambda --version', () => {
     const packageJson = require(path.join(__dirname, '..', 'package.json'))
     it('The current version is displayed', () => {


### PR DESCRIPTION
I changed the short option of `--tracingConfig` to `-c`.
Since there is little vacancy of the short option, I made this but please point out if there is anything good.

fix #384 
