### PR TITLE
bump to 0.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,3 +274,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Change: Ensure dotenv.load called before AWS load [#369](https://github.com/motdotla/node-lambda/pull/369)
 - Update README with latest output for 'node-lambda run -h' [#373](https://github.com/motdotla/node-lambda/pull/373)
 - Update Usage of README [#374](https://github.com/motdotla/node-lambda/pull/374)
+
+## [0.11.5] - 2017-12-11
+### Features
+- Move node-zip to devDependencies [#378](https://github.com/motdotla/node-lambda/pull/378)
+- Added the ability to set constants when scheduling a Lambda function Cloudwatch event [#380](https://github.com/motdotla/node-lambda/pull/380)
+- Update CI's Node.js to LTS and latest version [#386](https://github.com/motdotla/node-lambda/pull/386)
+- Update packages [#392](https://github.com/motdotla/node-lambda/pull/392)
+- Added class to set S3 events [#393](https://github.com/motdotla/node-lambda/pull/393)
+- Add updateS3Events to main [#394](https://github.com/motdotla/node-lambda/pull/394)
+- Refactoring lib/schedule_events.js [#395](https://github.com/motdotla/node-lambda/pull/395)
+
+### Bugfixes
+- Set docker run working directory so npm install works [#381](https://github.com/motdotla/node-lambda/pull/381)
+- Change short option of `--tracingConfig` to `-c` [#385](https://github.com/motdotla/node-lambda/pull/385)
+- Fix to use Proxy when run locally [#389](https://github.com/motdotla/node-lambda/pull/389)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "node-lambda",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
       "dev": true
     },
     "acorn-jsx": {
@@ -71,19 +71,28 @@
       "dev": true
     },
     "archiver": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.0.3.tgz",
-      "integrity": "sha1-tDYLtYSvFDeZGUJxbyHXxSPR270=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.0.tgz",
+      "integrity": "sha1-0t8ujVdzqCwdzOklzMQUUOqZmv0=",
       "requires": {
         "archiver-utils": "1.3.0",
-        "async": "2.5.0",
+        "async": "2.6.0",
         "buffer-crc32": "0.2.13",
-        "glob": "7.1.2",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
         "lodash": "4.17.4",
         "readable-stream": "2.3.3",
-        "tar-stream": "1.5.4",
-        "walkdir": "0.0.11",
+        "tar-stream": "1.5.5",
         "zip-stream": "1.2.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        }
       }
     },
     "archiver-utils": {
@@ -91,7 +100,7 @@
       "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
       "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
       "requires": {
-        "glob": "7.1.2",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
         "graceful-fs": "4.1.11",
         "lazystream": "1.0.0",
         "lodash": "4.17.4",
@@ -130,7 +139,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.8.2"
+        "es-abstract": "1.10.0"
       }
     },
     "arrify": {
@@ -146,22 +155,14 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.9.13",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.13.tgz",
-      "integrity": "sha512-72w1vrspLfSP4htDZWMgDya3gz7VFIojiaxWdXfJkpR/KouBvJZ2xoHxG79VwdGr8ZdG/b6zgwqoIG24QtRqCQ=="
-    },
-    "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-      "requires": {
-        "lodash": "4.17.4"
-      }
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
+      "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
     },
     "aws-sdk": {
-      "version": "2.164.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.164.0.tgz",
-      "integrity": "sha1-45iGV7fH6W58pan/UskLlrSyKdk=",
+      "version": "2.167.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.167.0.tgz",
+      "integrity": "sha1-8gff9/fpp4g9O2m9IlE0RJaKNr0=",
       "requires": {
         "buffer": "4.9.1",
         "crypto-browserify": "1.0.9",
@@ -188,7 +189,7 @@
       "integrity": "sha1-dpizuoL0k/cf8GCuISPNCAathnY=",
       "dev": true,
       "requires": {
-        "aws-sdk": "2.164.0",
+        "aws-sdk": "2.167.0",
         "sinon": "1.17.7",
         "traverse": "0.6.6"
       }
@@ -283,7 +284,7 @@
         "deep-eql": "3.0.1",
         "get-func-name": "2.0.0",
         "pathval": "1.1.0",
-        "type-detect": "4.0.3"
+        "type-detect": "4.0.5"
       }
     },
     "chalk": {
@@ -293,7 +294,7 @@
       "dev": true,
       "requires": {
         "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
         "has-ansi": "2.0.0",
         "strip-ansi": "3.0.1",
         "supports-color": "2.0.0"
@@ -351,9 +352,9 @@
       "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
     },
     "compress-commons": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.0.tgz",
-      "integrity": "sha1-WFhwku8g03y1i68AARLJJ4/3O58=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
       "requires": {
         "buffer-crc32": "0.2.13",
         "crc32-stream": "2.0.0",
@@ -375,6 +376,14 @@
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
         "typedarray": "0.0.6"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
       }
     },
     "contains-path": {
@@ -413,7 +422,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.30"
+        "es5-ext": "0.10.37"
       }
     },
     "data-uri-to-buffer": {
@@ -422,11 +431,10 @@
       "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
       }
     },
     "debug-log": {
@@ -441,7 +449,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.3"
+        "type-detect": "4.0.5"
       }
     },
     "deep-is": {
@@ -464,7 +472,7 @@
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
       "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
       "requires": {
-        "ast-types": "0.9.13",
+        "ast-types": "0.10.1",
         "escodegen": "1.9.0",
         "esprima": "3.1.3"
       }
@@ -476,8 +484,8 @@
       "dev": true,
       "requires": {
         "find-root": "1.1.0",
-        "glob": "7.1.2",
-        "ignore": "3.3.5",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
+        "ignore": "3.3.7",
         "pkg-config": "1.1.1",
         "run-parallel": "1.1.6",
         "uniq": "1.0.1"
@@ -495,7 +503,7 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz"
       }
     },
     "depd": {
@@ -503,19 +511,21 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
       "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
     },
+    "diff": {
+      "version": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
+    },
     "doctrine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
+      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "2.0.2"
       }
     },
     "dotenv": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-0.4.0.tgz",
+      "version": "https://registry.npmjs.org/dotenv/-/dotenv-0.4.0.tgz",
       "integrity": "sha1-9vs1E2PC2SIHJFxzeALJq1rhSVo="
     },
     "end-of-stream": {
@@ -524,6 +534,16 @@
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "requires": {
         "once": "1.4.0"
+      },
+      "dependencies": {
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "requires": {
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          }
+        }
       }
     },
     "error-ex": {
@@ -536,9 +556,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.2.tgz",
-      "integrity": "sha512-dvhwFL3yjQxNNsOWx6exMlaDrRHCRGMQlnx5lsXDCZ/J7G/frgIIl94zhZSp/galVAYp7VzPi1OrAHta89/yGQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
@@ -560,23 +580,23 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.30",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
-      "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
+      "version": "0.10.37",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
+      "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.1",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
     },
     "es6-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
+        "es5-ext": "0.10.37",
         "es6-symbol": "3.1.1"
       }
     },
@@ -587,8 +607,8 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
+        "es5-ext": "0.10.37",
+        "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -614,8 +634,8 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
+        "es5-ext": "0.10.37",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
       }
@@ -627,7 +647,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30"
+        "es5-ext": "0.10.37"
       }
     },
     "es6-weak-map": {
@@ -637,16 +657,14 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
+        "es5-ext": "0.10.37",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
     },
     "escodegen": {
       "version": "1.9.0",
@@ -681,17 +699,17 @@
         "babel-code-frame": "6.26.0",
         "chalk": "1.1.3",
         "concat-stream": "1.6.0",
-        "debug": "2.6.9",
-        "doctrine": "2.0.0",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "doctrine": "2.0.2",
         "escope": "3.6.0",
-        "espree": "3.5.1",
+        "espree": "3.5.2",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
-        "glob": "7.1.2",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
         "globals": "9.18.0",
-        "ignore": "3.3.5",
+        "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "0.12.0",
         "is-my-json-valid": "2.16.1",
@@ -700,7 +718,7 @@
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
         "natural-compare": "1.4.0",
         "optionator": "0.8.2",
         "path-is-inside": "1.0.2",
@@ -733,9 +751,9 @@
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
         "object-assign": "4.1.1",
-        "resolve": "1.4.0"
+        "resolve": "1.5.0"
       }
     },
     "eslint-module-utils": {
@@ -746,6 +764,23 @@
       "requires": {
         "debug": "2.6.9",
         "pkg-dir": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-import": {
@@ -756,7 +791,7 @@
       "requires": {
         "builtin-modules": "1.1.1",
         "contains-path": "0.1.0",
-        "debug": "2.6.9",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "0.2.3",
         "eslint-module-utils": "2.1.1",
@@ -784,10 +819,10 @@
       "integrity": "sha512-vIUQPuwbVYdz/CYnlTLsJrRy7iXHQjdEe5wz0XhhdTym3IInM/zZLlPf9nZ2mThsH0QcsieCOWs2vOeCy/22LQ==",
       "dev": true,
       "requires": {
-        "ignore": "3.3.5",
+        "ignore": "3.3.7",
         "minimatch": "3.0.4",
         "object-assign": "4.1.1",
-        "resolve": "1.4.0",
+        "resolve": "1.5.0",
         "semver": "5.3.0"
       },
       "dependencies": {
@@ -837,12 +872,12 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2",
+        "acorn": "5.2.1",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -887,7 +922,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30"
+        "es5-ext": "0.10.37"
       }
     },
     "events": {
@@ -919,6 +954,14 @@
       "requires": {
         "escape-string-regexp": "1.0.5",
         "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        }
       }
     },
     "file-entry-cache": {
@@ -984,16 +1027,32 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "4.1.6",
+        "jsonfile": "2.3.1",
+        "klaw": "1.3.0",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.6",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+          "integrity": "sha1-UUw4dysxvuLgi+3CGgrrOr9UwZ4="
+        },
+        "jsonfile": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz",
+          "integrity": "sha1-KLyynFlrW3qv005mKjKbpizYQvw="
+        },
+        "klaw": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz",
+          "integrity": "sha1-iFe/vB2CS63xPT0CQdi75G+xL3M="
+        }
       }
     },
     "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "ftp": {
@@ -1016,7 +1075,7 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
             "isarray": "0.0.1",
             "string_decoder": "0.10.31"
           }
@@ -1067,7 +1126,7 @@
       "integrity": "sha512-7aelVrYqCLuVjq2kEKRTH8fXPTC0xKTkM+G7UlFkEwCXY3sFbSxvY375JoFowOAYbkaU47SrBvOefUlLZZ+6QA==",
       "requires": {
         "data-uri-to-buffer": "1.2.0",
-        "debug": "2.6.9",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
         "extend": "3.0.1",
         "file-uri-to-path": "1.0.0",
         "ftp": "0.3.10",
@@ -1075,16 +1134,15 @@
       }
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
+      "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
+        "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
         "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
       }
     },
     "globals": {
@@ -1101,7 +1159,7 @@
       "requires": {
         "array-union": "1.0.2",
         "arrify": "1.0.1",
-        "glob": "7.1.2",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
@@ -1111,6 +1169,10 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "growl": {
+      "version": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
     },
     "has": {
       "version": "1.0.1",
@@ -1138,7 +1200,14 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
+        "statuses": "1.4.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
       }
     },
     "http-proxy-agent": {
@@ -1147,7 +1216,7 @@
       "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
       "requires": {
         "agent-base": "2.1.1",
-        "debug": "2.6.9",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
         "extend": "3.0.1"
       }
     },
@@ -1157,7 +1226,7 @@
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
       "requires": {
         "agent-base": "2.1.1",
-        "debug": "2.6.9",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
         "extend": "3.0.1"
       }
     },
@@ -1172,9 +1241,9 @@
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "ignore": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
-      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "imurmurhash": {
@@ -1184,18 +1253,16 @@
       "dev": true
     },
     "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+      "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
     },
     "inquirer": {
       "version": "0.12.0",
@@ -1219,9 +1286,9 @@
       }
     },
     "interpret": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-      "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
     "ip": {
@@ -1280,13 +1347,13 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
@@ -1327,6 +1394,24 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "jade": {
+      "version": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "requires": {
+        "commander": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY="
+        },
+        "mkdirp": {
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4="
+        }
+      }
+    },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
@@ -1365,14 +1450,6 @@
         "jsonify": "0.0.0"
       }
     },
-    "jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
-    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -1392,20 +1469,11 @@
       "dev": true
     },
     "jszip": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz",
+      "version": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz",
       "integrity": "sha1-dET9hVHd8+XacZj+oMkbyDCMwnQ=",
       "dev": true,
       "requires": {
-        "pako": "0.2.9"
-      }
-    },
-    "klaw": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "requires": {
-        "graceful-fs": "4.1.11"
+        "pako": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
       }
     },
     "lazystream": {
@@ -1473,9 +1541,8 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-      "integrity": "sha1-5W1jVBSO3o13B7WNFDIg/QjfD9U="
+      "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1486,24 +1553,57 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+      }
+    },
+    "mocha": {
+      "version": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "requires": {
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "diff": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+        "growl": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+        "jade": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+        "to-iso-string": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
+        },
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "requires": {
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
+          }
+        },
+        "minimatch": {
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "requires": {
+            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+            "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+          }
+        }
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
     },
     "mute-stream": {
       "version": "0.0.5",
@@ -1523,12 +1623,11 @@
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
     },
     "node-zip": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/node-zip/-/node-zip-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/node-zip/-/node-zip-1.1.1.tgz",
       "integrity": "sha1-lNGtZ0o81GoViN1zb0qaeMdX62I=",
       "dev": true,
       "requires": {
-        "jszip": "2.5.0"
+        "jszip": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz"
       }
     },
     "normalize-path": {
@@ -1569,11 +1668,10 @@
       }
     },
     "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
       }
     },
     "onetime": {
@@ -1631,19 +1729,32 @@
         "socks-proxy-agent": "3.0.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "socks-proxy-agent": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
           "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
           "requires": {
-            "agent-base": "4.1.1",
+            "agent-base": "4.1.2",
             "socks": "1.1.10"
           },
           "dependencies": {
             "agent-base": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.1.tgz",
-              "integrity": "sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==",
+              "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
+              "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
               "requires": {
                 "es6-promisify": "5.0.0"
               }
@@ -1665,9 +1776,8 @@
       }
     },
     "pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+      "version": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz",
+      "integrity": "sha1-Fa13KRU2KRPyDeSooWS0qsxhZdY=",
       "dev": true
     },
     "parse-json": {
@@ -1689,9 +1799,8 @@
       }
     },
     "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -1810,13 +1919,20 @@
       "integrity": "sha512-I23qaUnXmU/ItpXWQcMj9wMcZQTXnJNI7nakSR+q95Iht8H0+w3dCgTJdfnOQqOCX1FZwKLSgurCyEt11LM6OA==",
       "requires": {
         "agent-base": "2.1.1",
-        "debug": "2.6.9",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
         "extend": "3.0.1",
         "http-proxy-agent": "1.0.0",
         "https-proxy-agent": "1.0.0",
         "lru-cache": "2.6.5",
         "pac-proxy-agent": "2.0.0",
         "socks-proxy-agent": "2.1.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+          "integrity": "sha1-5W1jVBSO3o13B7WNFDIg/QjfD9U="
+        }
       }
     },
     "punycode": {
@@ -1852,6 +1968,13 @@
         "safe-buffer": "5.1.1",
         "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
       }
     },
     "readline2": {
@@ -1871,7 +1994,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.4.0"
+        "resolve": "1.5.0"
       }
     },
     "remove-trailing-separator": {
@@ -1890,9 +2013,9 @@
       }
     },
     "resolve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -1915,11 +2038,10 @@
       }
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz",
+      "integrity": "sha1-bl792kqi8DQX9rKldK7Cn0tlJwU=",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
       }
     },
     "run-async": {
@@ -1928,7 +2050,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
       }
     },
     "run-parallel": {
@@ -1975,10 +2097,14 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.0.4",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
+        "interpret": "1.1.0",
         "rechoir": "0.6.2"
       }
+    },
+    "sigmund": {
+      "version": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "sinon": {
       "version": "1.17.7",
@@ -2072,9 +2198,9 @@
       }
     },
     "statuses": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
     "string-width": {
       "version": "1.0.2",
@@ -2115,6 +2241,10 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
+    },
+    "supports-color": {
+      "version": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4="
     },
     "table": {
       "version": "3.8.3",
@@ -2164,9 +2294,9 @@
       }
     },
     "tar-stream": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-      "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "requires": {
         "bl": "1.2.1",
         "end-of-stream": "1.4.0",
@@ -2191,6 +2321,10 @@
       "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
       "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
     },
+    "to-iso-string": {
+      "version": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE="
+    },
     "traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
@@ -2212,9 +2346,9 @@
       }
     },
     "type-detect": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
+      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
       "dev": true
     },
     "typedarray": {
@@ -2258,15 +2392,7 @@
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
-        }
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
       }
     },
     "util-deprecate": {
@@ -2274,19 +2400,13 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "walkdir": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
-      "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI="
-    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
@@ -2295,7 +2415,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
       }
     },
     "xml2js": {
@@ -2331,7 +2451,7 @@
       "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
       "requires": {
         "archiver-utils": "1.3.0",
-        "compress-commons": "1.2.0",
+        "compress-commons": "1.2.2",
         "lodash": "4.17.4",
         "readable-stream": "2.3.3"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lambda",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Command line tool for locally running and remotely deploying your node.js applications to Amazon Lambda.",
   "main": "lib/main.js",
   "directories": {

--- a/test/main.js
+++ b/test/main.js
@@ -150,7 +150,7 @@ describe('lib/main', function () {
   })
 
   it('version should be set', () => {
-    assert.equal(lambda.version, '0.11.4')
+    assert.equal(lambda.version, '0.11.5')
   })
 
   describe('_codeDirectory', () => {


### PR DESCRIPTION
## [0.11.5] - 2017-12-11
### Features
- Move node-zip to devDependencies [#378](https://github.com/motdotla/node-lambda/pull/378)
- Added the ability to set constants when scheduling a Lambda function Cloudwatch event [#380](https://github.com/motdotla/node-lambda/pull/380)
- Update CI's Node.js to LTS and latest version [#386](https://github.com/motdotla/node-lambda/pull/386)
- Update packages [#392](https://github.com/motdotla/node-lambda/pull/392)
- Added class to set S3 events [#393](https://github.com/motdotla/node-lambda/pull/393)
- Add updateS3Events to main [#394](https://github.com/motdotla/node-lambda/pull/394)
- Refactoring lib/schedule_events.js [#395](https://github.com/motdotla/node-lambda/pull/395)

### Bugfixes
- Set docker run working directory so npm install works [#381](https://github.com/motdotla/node-lambda/pull/381)
- Change short option of `--tracingConfig` to `-c` [#385](https://github.com/motdotla/node-lambda/pull/385)
- Fix to use Proxy when run locally [#389](https://github.com/motdotla/node-lambda/pull/389)