### PR TITLE
Add support for custom endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ $ echo -e ".env\ndeploy.env\nevent.json\n.lambda" >> .gitignore
 
 ```
 AWS_ENVIRONMENT            // (default: '')
+AWS_ENDPOINT               // (default: '')
 CONFIG_FILE                // (default: '')
 EVENT_SOURCE_FILE          // (default: '')
 EXCLUDE_GLOBS              // (default: '')
@@ -117,6 +118,7 @@ Options:
   -x, --contextFile [context.json]      Context JSON File
   -M, --enableRunMultipleEvents [true]  Enable run multiple events
   -y, --proxy []                        Proxy server
+  -E, --endpoint []                     Use different endpoint (e.g. localstack, "http://127.0.0.1:4574")
 ```
 
 #### package
@@ -187,6 +189,12 @@ Options:
   -T, --deployTimeout [120000]        Deploy Timeout
   -z, --deployZipfile []              Deploy zipfile
   -y, --proxy []                      Proxy server
+```
+
+If you are deploying to a custom endpoint you may also need to pass in an access key/secret. For localstack these can be anything, but cannot be blank:
+
+```
+node-lambda deploy --endpoint http://localhost:4574 --accessKey '1234' --secretKey '1234'
 ```
 
 ## Custom Environment Variables

--- a/bin/node-lambda
+++ b/bin/node-lambda
@@ -15,6 +15,7 @@ const packageJson = fs.existsSync(path.join(process.cwd(), 'package.json'))
 const packageJsonName = packageJson.name || 'UnnamedFunction'
 
 const AWS_ENVIRONMENT = process.env.AWS_ENVIRONMENT || ''
+const AWS_ENDPOINT = process.env.AWS_ENDPOINT || ''
 const CONFIG_FILE = process.env.CONFIG_FILE || ''
 const EVENT_SOURCE_FILE = process.env.EVENT_SOURCE_FILE || ''
 const EXCLUDE_GLOBS = process.env.EXCLUDE_GLOBS || ''
@@ -62,6 +63,8 @@ program
   .description('Deploy your application to Amazon Lambda')
   .option('-e, --environment [AWS_ENVIRONMENT]', 'Choose environment {dev, staging, production}',
     AWS_ENVIRONMENT)
+  .option('-E, --endpoint [AWS_ENDPOINT]', 'Choose endpoint (e.g. localstack, "http://127.0.0.1:4574")',
+    AWS_ENDPOINT)
   .option('-a, --accessKey [AWS_ACCESS_KEY_ID]', 'AWS Access Key', AWS_ACCESS_KEY_ID)
   .option('-s, --secretKey [AWS_SECRET_ACCESS_KEY]', 'AWS Secret Key', AWS_SECRET_ACCESS_KEY)
   .option('-P, --profile [AWS_PROFILE]', 'AWS Profile', AWS_PROFILE)

--- a/lib/main.js
+++ b/lib/main.js
@@ -797,6 +797,10 @@ they may not work as expected in the Lambda environment.
         aws.config.httpOptions.agent = proxy(program.proxy)
       }
 
+      if (program.endpoint) {
+        aws.config.endpoint = program.endpoint
+      }
+
       aws.config.update(awsSecurity)
 
       const lambda = new aws.Lambda({ apiVersion: '2015-03-31' })


### PR DESCRIPTION
Adds cli parameter and environment variable to specify the AWS endpoint to use when deploying. Allows you to deploy to [localstack](https://github.com/localstack/localstack) or AWS similar environments instead of only AWS.