### PR TITLE
Fix to set array when same bucket

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -710,12 +710,7 @@ they may not work as expected in the Lambda environment.
     const paramsList = s3EventsList.map(s3event =>
       Object.assign(s3event, { FunctionArn: functionArn }))
 
-    // series
-    return paramsList.map(params => {
-      return s3Events.add(params)
-    }).reduce((a, b) => {
-      return a.then(b)
-    }, Promise.resolve()).then(() => {
+    return s3Events.add(paramsList).then(() => {
       // Since it is similar to _updateScheduleEvents, it returns meaningful values
       return paramsList
     })

--- a/lib/s3_events.js
+++ b/lib/s3_events.js
@@ -43,7 +43,7 @@ class S3Events {
     })
   }
 
-  _putBucketNotificationConfigurationParams (params) {
+  _lambdaFunctionConfiguration (params) {
     const lambdaFunctionConfiguration = {
       Events: params.Events,
       LambdaFunctionArn: params.FunctionArn
@@ -52,29 +52,53 @@ class S3Events {
       lambdaFunctionConfiguration.Filter = params.Filter
     }
 
-    return {
-      Bucket: params.Bucket,
-      NotificationConfiguration: {
-        LambdaFunctionConfigurations: [
-          lambdaFunctionConfiguration
-        ]
-      }
-    }
+    return lambdaFunctionConfiguration
   }
 
-  _putBucketNotificationConfiguration (params) {
+  _paramsListToBucketNotificationConfigurations (paramsList) {
+    const lambdaFunctionConfigurations = {}
+    for (const params of paramsList) {
+      if (lambdaFunctionConfigurations[params.Bucket] == null) {
+        lambdaFunctionConfigurations[params.Bucket] = [
+          this._lambdaFunctionConfiguration(params)
+        ]
+        continue
+      }
+      lambdaFunctionConfigurations[params.Bucket].push(
+        this._lambdaFunctionConfiguration(params)
+      )
+    }
+    return Object.keys(lambdaFunctionConfigurations).map((bucket) => {
+      return {
+        Bucket: bucket,
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations:
+            lambdaFunctionConfigurations[bucket]
+        }
+      }
+    })
+  }
+
+  _putBucketNotificationConfiguration (putBucketNotificationConfigurationParams) {
     return new Promise((resolve, reject) => {
-      const _params = this._putBucketNotificationConfigurationParams(params)
-      this.s3.putBucketNotificationConfiguration(_params, (err, data) => {
+      this.s3.putBucketNotificationConfiguration(putBucketNotificationConfigurationParams, (err, data) => {
         if (err) reject(err)
         resolve(data)
       })
     })
   }
 
-  add (params) {
-    return this._addPermission(params).then(() => {
-      return this._putBucketNotificationConfiguration(params)
+  add (paramsList) {
+    return paramsList.map(params => {
+      return this._addPermission(params)
+    }).reduce((a, b) => {
+      return a.then(b)
+    }, Promise.resolve()).then(() => {
+      return this._paramsListToBucketNotificationConfigurations(paramsList).map(putBucketNotificationConfigurationParams => {
+        return this._putBucketNotificationConfiguration(putBucketNotificationConfigurationParams)
+      }).reduce((a, b) => {
+        return a.then(b)
+      })
     })
   }
 }


### PR DESCRIPTION
In the case of the same bucket, it is necessary to set it as an array in
`LambdaFunctionConfigurations` and make it one request.

fixes: #422 