### PR TITLE
Stop supporting Node.js 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - 4
   - 6
   - 8
   - 9

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
     - nodejs_version: '9'
     - nodejs_version: '8'
     - nodejs_version: '6'
-    - nodejs_version: '4'
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
     "klaw": "^2.1.1",
     "minimatch": "^3.0.3",
     "proxy-agent": "^2.2.0"
+  },
+  "engines": {
+    "node": ">= 6.0.0"
   }
 }


### PR DESCRIPTION
* Node.js 4 is End-of-Life. https://github.com/nodejs/Release
* Support of nodejs 4.3 of Lambda runtime will continue

fixes #429 
If the #429 is not approved, close this PR as well.
