### PR TITLE
Log result of an async handler method by resolving promise if a promise

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -123,8 +123,10 @@ event_sources.json and ${program.eventFile} files as needed.`)
       nameSpace.set('segment', new AWSXRay.Segment('annotations'))
       const result = handler(event, context, callback)
       if (result != null) {
-        console.log('Result:')
-        console.log(JSON.stringify(result))
+        Promise.resolve(result).then(resolved => {
+          console.log('Result:')
+          console.log(JSON.stringify(resolved))
+        })
       }
     })
   }


### PR DESCRIPTION
This PR uses Promise.resolve to handle promise and non-promise results from async handlers and log these results to the console.

See https://github.com/motdotla/node-lambda/pull/427 for earlier discussion