### PR TITLE
Added handling to catch and log error return from async lambda

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -123,10 +123,16 @@ event_sources.json and ${program.eventFile} files as needed.`)
       nameSpace.set('segment', new AWSXRay.Segment('annotations'))
       const result = handler(event, context, callback)
       if (result != null) {
-        Promise.resolve(result).then(resolved => {
-          console.log('Result:')
-          console.log(JSON.stringify(resolved))
-        })
+        Promise.resolve(result).then(
+          resolved => {
+            console.log('Result:')
+            console.log(JSON.stringify(resolved))
+          },
+          rejected => {
+            console.log('Error:')
+            console.log(rejected)
+          }
+        )
       }
     })
   }


### PR DESCRIPTION
For: https://github.com/motdotla/node-lambda/issues/442
Adds a rejected handler for the result of an async lambda