### PR TITLE
Implemente to specify bucket name of S3

### DIFF
--- a/lib/s3_deploy.js
+++ b/lib/s3_deploy.js
@@ -32,7 +32,33 @@ class S3Deploy {
       .digest('hex')
   }
 
+  _convertRegionStringToEnvVarName (region) {
+    if (region == null) return 'undefined'
+    return region.replace(/-/g, '_').toUpperCase()
+  }
+
+  _getBucketNameFromEnvVar (region) {
+    const key = [
+      'S3',
+      this._convertRegionStringToEnvVarName(region),
+      'BUCKET'
+    ].join('_')
+    return process.env[key]
+  }
+
+  _getS3KeyPrefixFromEnvVar (region) {
+    const key = [
+      'S3',
+      this._convertRegionStringToEnvVarName(region),
+      'PREFIX'
+    ].join('_')
+    return process.env[key]
+  }
+
   _bucketName (params) {
+    const bucketNameFromEnvVar = this._getBucketNameFromEnvVar(params.region)
+    if (bucketNameFromEnvVar != null) return bucketNameFromEnvVar
+
     return [
       params.FunctionName,
       params.region,
@@ -43,7 +69,12 @@ class S3Deploy {
   }
 
   _s3Key (params) {
-    return `deploy-package-${params.FunctionName}.zip`
+    const s3Prefix = this._getS3KeyPrefixFromEnvVar(params.region)
+    const keys = [`deploy-package-${params.FunctionName}.zip`]
+    if (s3Prefix != null) {
+      keys.unshift(s3Prefix.replace(/\/$/, ''))
+    }
+    return keys.join('/')
   }
 
   _getS3Location (region) {


### PR DESCRIPTION
As options increase too much, we do not add it to the options of the command.

Set to `.env` as follows.

```
S3_US_EAST_1_BUCKET="bucket-name"
S3_US_EAST_1_PREFIX="key-prefix"
```

fixes: #456