### PR TITLE
bump to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,3 +309,31 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Bugfixes
 - remove env var value from commanderjs flag definition [#409](https://github.com/motdotla/node-lambda/pull/409)
+
+## [0.12.0] - 2018-08-10
+### Features
+- Implemente to specify bucket name of S3 [#458](https://github.com/motdotla/node-lambda/pull/458)
+- Implement deployment using S3 (Create a bucket for each region.) [#455](https://github.com/motdotla/node-lambda/pull/455)
+- Add class for uploading deploy package to S3 [#454](https://github.com/motdotla/node-lambda/pull/454)
+- Fix to throw an error except ResourceNotFoundException [#452](https://github.com/motdotla/node-lambda/pull/452)
+- Feature upload to s3 and deploy from bucket [#446](https://github.com/motdotla/node-lambda/pull/446)
+- npm update [#445](https://github.com/motdotla/node-lambda/pull/445)
+- Upgrade dependent packages [#441](https://github.com/motdotla/node-lambda/pull/441)
+- Add simple test of `_deployToRegion()` and `deploy()` [#439](https://github.com/motdotla/node-lambda/pull/439)
+- Remove unnecessary package load in `test/main.js` [#438](https://github.com/motdotla/node-lambda/pull/438)
+- Add cache of `node modules` to CI setting [#436](https://github.com/motdotla/node-lambda/pull/436)
+- Modify `require` to `{ }` statement [#435](https://github.com/motdotla/node-lambda/pull/435)
+- Fix to use `includes` instead of `indexOf` [#433](https://github.com/motdotla/node-lambda/pull/433)
+- Remove test code for Node.js4 [#432](https://github.com/motdotla/node-lambda/pull/432)
+- Upgrade `fs-extra` [#431](https://github.com/motdotla/node-lambda/pull/431)
+- Stop supporting Node.js 4 [#430](https://github.com/motdotla/node-lambda/pull/430)
+- Fix using `klaw` instead of `fs.walk` [#424](https://github.com/motdotla/node-lambda/pull/424)
+- Add Node.js10 to CI setting [#428](https://github.com/motdotla/node-lambda/pull/428)
+
+### Bugfixes
+- Fix StatementId [#451](https://github.com/motdotla/node-lambda/pull/451)
+- Bugfix of initialValue of recude in s3events [#447](https://github.com/motdotla/node-lambda/pull/447)
+- Added handling to catch and log error return from async lambda [#443](https://github.com/motdotla/node-lambda/pull/443)
+- Log result of an async handler method by resolving promise if a promise [#440](https://github.com/motdotla/node-lambda/pull/440)
+- Fix to display return value of handler [#427](https://github.com/motdotla/node-lambda/pull/427)
+- Fix to set array when same bucket [#423](https://github.com/motdotla/node-lambda/pull/423)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,18 @@
 {
   "name": "node-lambda",
-  "version": "0.11.7",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/commons": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
+      "integrity": "sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
     "@sinonjs/formatio": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
@@ -195,9 +204,9 @@
       "integrity": "sha1-0WkB0QzOxZUWwZe5zNiTBom4E7Q="
     },
     "aws-sdk": {
-      "version": "2.279.1",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.279.1.tgz",
-      "integrity": "sha512-2vkvg53XaTmPYW6f7YFUEHfNGzOZqKzUboaEkjz/wblmQmDS7J5DO5KTv52wsNFOICBGXgZPCblwD+oP7iT8iA==",
+      "version": "2.290.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.290.0.tgz",
+      "integrity": "sha512-4AiExL06NsjrYqec/GdZP6qsquppFhaJE9hKZNw1c4ApjiGCRucfSlMvaZ6aZw76MG9b2Mi8mboGXOYW8nTGJQ==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -208,28 +217,12 @@
         "url": "0.10.3",
         "uuid": "3.1.0",
         "xml2js": "0.4.19"
-      },
-      "dependencies": {
-        "xml2js": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-          "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-          "requires": {
-            "sax": ">=0.6.0",
-            "xmlbuilder": "~9.0.1"
-          }
-        },
-        "xmlbuilder": {
-          "version": "9.0.7",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
-        }
       }
     },
     "aws-sdk-mock": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk-mock/-/aws-sdk-mock-4.0.0.tgz",
-      "integrity": "sha512-wW79xLFuinT4pXVCql3sokddHGaEyG7sM8rCV5CTmaemxG/w2T0dN9Z6mAg5J2ZnnJLa8kkO2lg7ltd6U05ihA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-mock/-/aws-sdk-mock-4.1.0.tgz",
+      "integrity": "sha512-JZoLKMzgYXzDdpyKdgw+4JG9nKFd/oab8VDTnwd6iY/mHjmuQUx7kFlOMZ5pNdMK/jcY02Ks7oECHC+ZnwLwqw==",
       "dev": true,
       "requires": {
         "aws-sdk": "^2.260.1",
@@ -326,12 +319,6 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
-    },
-    "browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
     },
     "buffer": {
       "version": "4.9.1",
@@ -494,9 +481,9 @@
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "commander": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
-      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew=="
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
     },
     "compress-commons": {
       "version": "1.2.2",
@@ -1287,12 +1274,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
-    "growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -1315,12 +1296,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
-    },
-    "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
     "hosted-git-info": {
@@ -1728,47 +1703,6 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
-      }
-    },
-    "mocha": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-      "dev": true,
-      "requires": {
-        "browser-stdout": "1.3.1",
-        "commander": "2.15.1",
-        "debug": "3.1.0",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
-        "growl": "1.10.5",
-        "he": "1.1.1",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "supports-color": "5.4.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "ms": {
@@ -2391,11 +2325,12 @@
       "dev": true
     },
     "sinon": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.1.4.tgz",
-      "integrity": "sha512-NFEts+4D4jp2sBjL94fQpZk5o73kzn/g58+I9Dp15i9vsnT4Lk1UEyUf2jACODWLG6Pz/llF0sArYUw47Aarmg==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.1.5.tgz",
+      "integrity": "sha512-TcbRoWs1SdY6NOqfj0c9OEQquBoZH+qEf8799m1jjcbfWrrpyCQ3B/BpX7+NKa7Vn33Jl+Z50H4Oys3bzygK2Q==",
       "dev": true,
       "requires": {
+        "@sinonjs/commons": "^1.0.1",
         "@sinonjs/formatio": "^2.0.0",
         "@sinonjs/samsam": "^2.0.0",
         "diff": "^3.5.0",
@@ -2784,6 +2719,20 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xregexp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lambda",
-  "version": "0.11.7",
+  "version": "0.12.0",
   "description": "Command line tool for locally running and remotely deploying your node.js applications to Amazon Lambda.",
   "main": "lib/main.js",
   "directories": {
@@ -32,7 +32,7 @@
   "author": "motdotla",
   "license": "BSD-2-Clause",
   "devDependencies": {
-    "aws-sdk-mock": "^4.0.0",
+    "aws-sdk-mock": "^4.1.0",
     "chai": "^4.1.2",
     "mocha": "",
     "node-zip": "^1.1.1",
@@ -40,9 +40,9 @@
   },
   "dependencies": {
     "archiver": "^2.1.1",
-    "aws-sdk": "^2.279.1",
+    "aws-sdk": "^2.290.0",
     "aws-xray-sdk-core": "^1.3.0",
-    "commander": "^2.16.0",
+    "commander": "^2.17.1",
     "continuation-local-storage": "^3.2.1",
     "dotenv": "^6.0.0",
     "fs-extra": "^7.0.0",

--- a/test/main.js
+++ b/test/main.js
@@ -153,7 +153,7 @@ describe('lib/main', function () {
   })
 
   it('version should be set', () => {
-    assert.equal(lambda.version, '0.11.7')
+    assert.equal(lambda.version, '0.12.0')
   })
 
   describe('_codeDirectory', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,9 +159,9 @@ atomic-batcher@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/atomic-batcher/-/atomic-batcher-1.0.2.tgz#d16901d10ccec59516c197b9ccd8930689b813b4"
 
-aws-sdk-mock@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk-mock/-/aws-sdk-mock-4.0.0.tgz#759d938f5df5eda4ef90b0535059a61b2e57f4dd"
+aws-sdk-mock@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk-mock/-/aws-sdk-mock-4.1.0.tgz#e156de7010640f0a399072c852146fbfea9ad4aa"
   dependencies:
     aws-sdk "^2.260.1"
     sinon "^6.0.0"
@@ -181,9 +181,9 @@ aws-sdk@^2.260.1:
     uuid "3.1.0"
     xml2js "0.4.17"
 
-aws-sdk@^2.279.1:
-  version "2.279.1"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.279.1.tgz#3a4fd4167932e4361dbdcfcb174ce4840ffcbf20"
+aws-sdk@^2.290.0:
+  version "2.290.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.290.0.tgz#e0e4777a62ad29df3b86521a103b3f02189a30f5"
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -349,9 +349,9 @@ commander@2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.16.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
+commander@^2.17.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
 compress-commons@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
#457

## [0.12.0] - 2018-08-10
### Features
- Implemente to specify bucket name of S3 [#458](https://github.com/motdotla/node-lambda/pull/458)
- Implement deployment using S3 (Create a bucket for each region.) [#455](https://github.com/motdotla/node-lambda/pull/455)
- Add class for uploading deploy package to S3 [#454](https://github.com/motdotla/node-lambda/pull/454)
- Fix to throw an error except ResourceNotFoundException [#452](https://github.com/motdotla/node-lambda/pull/452)
- Feature upload to s3 and deploy from bucket [#446](https://github.com/motdotla/node-lambda/pull/446)
- npm update [#445](https://github.com/motdotla/node-lambda/pull/445)
- Upgrade dependent packages [#441](https://github.com/motdotla/node-lambda/pull/441)
- Add simple test of `_deployToRegion()` and `deploy()` [#439](https://github.com/motdotla/node-lambda/pull/439)
- Remove unnecessary package load in `test/main.js` [#438](https://github.com/motdotla/node-lambda/pull/438)
- Add cache of `node modules` to CI setting [#436](https://github.com/motdotla/node-lambda/pull/436)
- Modify `require` to `{ }` statement [#435](https://github.com/motdotla/node-lambda/pull/435)
- Fix to use `includes` instead of `indexOf` [#433](https://github.com/motdotla/node-lambda/pull/433)
- Remove test code for Node.js4 [#432](https://github.com/motdotla/node-lambda/pull/432)
- Upgrade `fs-extra` [#431](https://github.com/motdotla/node-lambda/pull/431)
- Stop supporting Node.js 4 [#430](https://github.com/motdotla/node-lambda/pull/430)
- Fix using `klaw` instead of `fs.walk` [#424](https://github.com/motdotla/node-lambda/pull/424)
- Add Node.js10 to CI setting [#428](https://github.com/motdotla/node-lambda/pull/428)

### Bugfixes
- Fix StatementId [#451](https://github.com/motdotla/node-lambda/pull/451)
- Bugfix of initialValue of recude in s3events [#447](https://github.com/motdotla/node-lambda/pull/447)
- Added handling to catch and log error return from async lambda [#443](https://github.com/motdotla/node-lambda/pull/443)
- Log result of an async handler method by resolving promise if a promise [#440](https://github.com/motdotla/node-lambda/pull/440)
- Fix to display return value of handler [#427](https://github.com/motdotla/node-lambda/pull/427)
- Fix to set array when same bucket [#423](https://github.com/motdotla/node-lambda/pull/423)