### PR TITLE
Update CI test to LTS version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - 6
   - 8
-  - 9
   - 10
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 environment:
   matrix:
     - nodejs_version: '10'
-    - nodejs_version: '9'
     - nodejs_version: '8'
     - nodejs_version: '6'
 install:


### PR DESCRIPTION
Node.js 9 is End-of-Life.
https://github.com/nodejs/Release#end-of-life-releases