### PR TITLE
Fix value of StartingPosition

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -617,6 +617,13 @@ they may not work as expected in the Lambda environment.
     })
   }
 
+  _getStartingPosition (eventSource) {
+    if (eventSource.EventSourceArn.indexOf('arn:aws:sqs:') === 0) {
+      return null
+    }
+    return eventSource.StartingPosition ? eventSource.StartingPosition : 'LATEST'
+  }
+
   _updateEventSources (lambda, functionName, existingEventSourceList, eventSourceList) {
     if (eventSourceList == null) {
       return Promise.resolve([])
@@ -647,7 +654,7 @@ they may not work as expected in the Lambda environment.
           'EventSourceArn': eventSourceList[i]['EventSourceArn'],
           'Enabled': eventSourceList[i]['Enabled'] ? eventSourceList[i]['Enabled'] : false,
           'BatchSize': eventSourceList[i]['BatchSize'] ? eventSourceList[i]['BatchSize'] : 100,
-          'StartingPosition': eventSourceList[i]['StartingPosition'] ? eventSourceList[i]['StartingPosition'] : 'LATEST'
+          'StartingPosition': this._getStartingPosition(eventSourceList[i])
         })
       }
     }

--- a/test/main.js
+++ b/test/main.js
@@ -989,6 +989,33 @@ describe('lib/main', function () {
     })
   })
 
+  describe('_getStartingPosition', () => {
+    it('null in SQS', () => {
+      assert.isNull(lambda._getStartingPosition({
+        EventSourceArn: 'arn:aws:sqs:us-east-1:sqs-queuename1'
+      }))
+    })
+
+    it('When there is no setting', () => {
+      assert.equal(
+        lambda._getStartingPosition({
+          EventSourceArn: 'arn:aws:kinesis:test'
+        }),
+        'LATEST'
+      )
+    })
+
+    it('With StartingPosition', () => {
+      assert.equal(
+        lambda._getStartingPosition({
+          EventSourceArn: 'arn:aws:kinesis:test',
+          StartingPosition: 'test position'
+        }),
+        'test position'
+      )
+    })
+  })
+
   describe('_updateEventSources', () => {
     const eventSourcesJsonValue = {
       EventSourceMappings: [{


### PR DESCRIPTION
In the SQS event, since the value of `StartingPosition` is unnecessary, it returns null.

fixes #466