### PR TITLE
Drop nodejs4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
 jobs:
   include:
     - stage: npm release
-      node_js: node
+      node_js: 10
       script: echo "Deploying to npm ..."
       deploy:
         provider: npm

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ AWS Lambda will let you set environment variables for your function. Use the sam
 
 ## Node.js Runtime Configuration
 
-AWS Lambda now supports Node.js 8.10, 6.10 and Node.js 4.3. Please also check the [Programming Model (Node.js)](http://docs.aws.amazon.com/lambda/latest/dg/programming-model.html) page.
+AWS Lambda now supports Node.js 8.10 and Node.js 6.10. Please also check the [Programming Model (Node.js)](http://docs.aws.amazon.com/lambda/latest/dg/programming-model.html) page.
 
 ## Post install script
 When running `node-lambda deploy` if you need to do some action after `npm install --production` and before deploying to AWS Lambda (e.g. replace some modules with precompiled ones or download some libraries, replace some config file depending on environment) you can create `post_install.sh` script. If the file exists the script will be executed (and output shown after execution) if not it is skipped. Environment string is passed to script as first parameter so you can use it if needed. Make sure that the script is executable.

--- a/lib/main.js
+++ b/lib/main.js
@@ -52,7 +52,7 @@ event_sources.json and ${program.eventFile} files as needed.`)
   }
 
   run (program) {
-    if (!['nodejs4.3', 'nodejs6.10', 'nodejs8.10'].includes(program.runtime)) {
+    if (!['nodejs6.10', 'nodejs8.10'].includes(program.runtime)) {
       console.error(`Runtime [${program.runtime}] is not supported.`)
       process.exit(254)
     }


### PR DESCRIPTION
Node.js 4.3 was dropped from the document.
https://docs.aws.amazon.com/lambda/latest/dg/programming-model.html

`.travis.yml` has nothing to do with the subject, but since CI fails, I fixed it.

```
error aws-xray-sdk-core@2.0.1: The engine "node" is incompatible with this module. Expected version ">= 4.x <= 10.x". Got "11.0.0"
```

fix #425