### PR TITLE
Add keepNodeModules option in package

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Options:
   -e, --environment [development]   Choose environment {dev, staging, production}
   -x, --excludeGlobs [event.json]   Space-separated glob pattern(s) for additional exclude files (e.g. "event.json dotenv.sample")
   -D, --prebuiltDirectory []        Prebuilt directory
+  -m, --keepNodeModules [false]     Keep the current node_modules and skip the npm install step
 ```
 
 #### deploy

--- a/bin/node-lambda
+++ b/bin/node-lambda
@@ -58,6 +58,7 @@ const AWS_DLQ_TARGET_ARN = (() => {
 })()
 const PROXY = process.env.PROXY || process.env.http_proxy || ''
 const ENABLE_RUN_MULTIPLE_EVENTS = true
+const KEEP_NODE_MODULES = process.env.KEEP_NODE_MODULES || false
 
 program
   .command('deploy')
@@ -119,6 +120,7 @@ program
   .option('-x, --excludeGlobs [EXCLUDE_GLOBS]',
     'Space-separated glob pattern(s) for additional exclude files (e.g. "event.json dotenv.sample")', EXCLUDE_GLOBS)
   .option('-D, --prebuiltDirectory [PREBUILT_DIRECTORY]', 'Prebuilt directory', PREBUILT_DIRECTORY)
+  .option('-m, --keepNodeModules [KEEP_NODE_MODULES]', 'Keep the current node_modules directory.', KEEP_NODE_MODULES)
   .action((prg) => lambda.package(prg))
 
 program

--- a/lib/main.js
+++ b/lib/main.js
@@ -462,20 +462,36 @@ so you can easily test run multiple events.
     return path.join(os.tmpdir(), `${path.basename(path.resolve('.'))}-lambda`)
   }
 
-  _cleanDirectory (codeDirectory) {
-    return new Promise((resolve, reject) => {
-      fs.remove(codeDirectory, (err) => {
-        if (err) return reject(err)
-        resolve()
-      })
-    }).then(() => {
+  _cleanDirectory (codeDirectory, keepNodeModules) {
+    if (!fs.existsSync(codeDirectory)) {
       return new Promise((resolve, reject) => {
         fs.mkdirs(codeDirectory, (err) => {
           if (err) return reject(err)
           resolve()
         })
       })
-    })
+    } else {
+      return new Promise((resolve, reject) => {
+        fs.readdir(codeDirectory, (err, files) => {
+          if (err) return reject(err)
+
+          Promise.all(files.map(file => {
+            return new Promise((resolve, reject) => {
+              if (keepNodeModules && file === 'node_modules') {
+                resolve()
+              } else {
+                fs.remove(path.join(codeDirectory, file), err => {
+                  if (err) return reject(err)
+                  resolve()
+                })
+              }
+            })
+          })).then(() => {
+            resolve()
+          })
+        })
+      })
+    }
   }
 
   _setRunTimeEnvironmentVars (program) {
@@ -590,13 +606,17 @@ they may not work as expected in the Lambda environment.
     const lambdaSrcDirectory = program.sourceDirectory ? program.sourceDirectory.replace(/\/$/, '') : '.'
 
     return Promise.resolve().then(() => {
-      return this._cleanDirectory(codeDirectory)
+      return this._cleanDirectory(codeDirectory, program.keepNodeModules)
     }).then(() => {
       console.log('=> Moving files to temporary directory')
       return this._fileCopy(program, lambdaSrcDirectory, codeDirectory, true)
     }).then(() => {
-      console.log('=> Running npm install --production')
-      return this._npmInstall(program, codeDirectory)
+      if (program.keepNodeModules) {
+        return Promise.resolve()
+      } else {
+        console.log('=> Running npm install --production')
+        return this._npmInstall(program, codeDirectory)
+      }
     }).then(() => {
       return this._postInstallScript(program, codeDirectory)
     }).then(() => {


### PR DESCRIPTION
Hello,

Depending on your lambda dependencies, `npm install` could be really slow to execute. 
Furthermore, in the case of a docker build, these dependencies are installed each time we package our lambda (because of the codeDirectory which is cleaned and mounted in `/var/task`).

So I added the `keepNodeModules` option in order to skip the `npm i` step for cases where we don’t need to reinstall all the dependencies if we don’t add any new module.
Also I put this option to false by default in order to not disturb the actual behaviour.

Thx again for this project !