### PR TITLE
Add dockerVolumes option in package in order to mount additional volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Options:
   -e, --environment [development]   Choose environment {dev, staging, production}
   -x, --excludeGlobs [event.json]   Space-separated glob pattern(s) for additional exclude files (e.g. "event.json dotenv.sample")
   -D, --prebuiltDirectory []        Prebuilt directory
+  -v, --dockerVolumes []            Additional docker volumes to mount. Each volume definition has to be separated by a space (e.g. "$HOME/.gitconfig:/etc/gitconfig $HOME/.ssh:/root/.ssh"
 ```
 
 #### deploy

--- a/bin/node-lambda
+++ b/bin/node-lambda
@@ -58,6 +58,7 @@ const AWS_DLQ_TARGET_ARN = (() => {
 })()
 const PROXY = process.env.PROXY || process.env.http_proxy || ''
 const ENABLE_RUN_MULTIPLE_EVENTS = true
+const DOCKER_VOLUMES = process.env.DOCKER_VOLUMES || ''
 
 program
   .command('deploy')
@@ -119,6 +120,7 @@ program
   .option('-x, --excludeGlobs [EXCLUDE_GLOBS]',
     'Space-separated glob pattern(s) for additional exclude files (e.g. "event.json dotenv.sample")', EXCLUDE_GLOBS)
   .option('-D, --prebuiltDirectory [PREBUILT_DIRECTORY]', 'Prebuilt directory', PREBUILT_DIRECTORY)
+  .option('-v, --dockerVolumes [DOCKER_VOLUMES]', 'Additional docker volumes to mount. Each volume definition has to be separated by a space (e.g. "$HOME/.gitconfig:/etc/gitconfig $HOME/.ssh:/root/.ssh")', DOCKER_VOLUMES)
   .action((prg) => lambda.package(prg))
 
 program

--- a/lib/main.js
+++ b/lib/main.js
@@ -343,10 +343,20 @@ so you can easily test run multiple events.
 
   _npmInstall (program, codeDirectory) {
     const dockerBaseOptions = [
-      'run', '--rm', '-v', `${fs.realpathSync(codeDirectory)}:/var/task`, '-w', '/var/task',
-      program.dockerImage,
-      'npm', '-s', 'install', '--production'
+      'run', '--rm',
+      '-v', `${fs.realpathSync(codeDirectory)}:/var/task`,
+      '-w', '/var/task'
     ]
+
+    let dockerVolumesOptions = []
+    program.dockerVolumes && program.dockerVolumes.split(' ').forEach((volume) => {
+      dockerVolumesOptions = dockerVolumesOptions.concat(['-v', volume])
+    })
+
+    const dockerCommand = [program.dockerImage, 'npm', '-s', 'install', '--production']
+
+    const dockerOptions = dockerBaseOptions.concat(dockerVolumesOptions).concat(dockerCommand)
+
     const npmInstallBaseOptions = [
       '-s',
       'install',
@@ -362,12 +372,12 @@ so you can easily test run multiple events.
         if (process.platform === 'win32') {
           return {
             command: 'cmd.exe',
-            options: ['/c', 'docker'].concat(dockerBaseOptions)
+            options: ['/c', 'docker'].concat(dockerOptions)
           }
         }
         return {
           command: 'docker',
-          options: dockerBaseOptions
+          options: dockerOptions
         }
       }
 


### PR DESCRIPTION
Hello again !

In some docker use cases it could be useful to be able to mount other volumes than the one with the sources of the lambda. 
As an example, it will permit to mount credentials informations from an ssh directory. Also I think this will solve the issue talked in #379 cause it will be possible to mount a file with the aws credentials without adding all the other options.