### PR TITLE
Update s3deploy bucket handling

### DIFF
--- a/lib/s3_deploy.js
+++ b/lib/s3_deploy.js
@@ -65,7 +65,7 @@ class S3Deploy {
       this._md5(params.FunctionName + params.region)
     ]
       .join('-')
-      .substr(0, 63)
+      .substr(0, 63).toLowerCase()
   }
 
   _s3Key (params) {


### PR DESCRIPTION
S3 buckets cannot have uppercase chars, while Lambda functions can. The bucket name needs to adjusted to meet this restriction.