### PR TITLE
feat: warn the user on supplying unknown commands

### DIFF
--- a/bin/node-lambda
+++ b/bin/node-lambda
@@ -149,6 +149,12 @@ program
   .option('-x, --contextFile [CONTEXT_FILE]', 'Context JSON File', CONTEXT_FILE)
   .action((prg) => lambda.setup(prg))
 
+program.on('command:*', (cmd) => {
+  console.log(`Unknown command ${cmd}`)
+  console.log()
+  program.help()
+})
+
 program
   .version(lambda.version)
   .parse(process.argv)


### PR DESCRIPTION
Fixes #493

`node-lambda random`

```md
Unknown command random

Usage: node-lambda [options] [command]

Options:
  -V, --version          output the version number
  -h, --help             output usage information

Commands:
  deploy [options]       Deploy your application to Amazon Lambda
  package|zip [options]  Create zipped package for Amazon Lambda deployment
  run|execute [options]  Run your Amazon Lambda application locally
  setup [options]        Sets up the .env file.
```