### PR TITLE
Use `ci` instead of `install` when installing packages

### DIFF
--- a/bin/node-lambda
+++ b/bin/node-lambda
@@ -95,7 +95,7 @@ program
   .option('-R, --retentionInDays [AWS_LOGS_RETENTION_IN_DAYS]', 'CloudWatchLogs retentionInDays settings',
     AWS_LOGS_RETENTION_IN_DAYS)
   .option('-G, --sourceDirectory [SRC_DIRECTORY]', 'Path to lambda source Directory (e.g. "./some-lambda")', SRC_DIRECTORY)
-  .option('-I, --dockerImage [DOCKER_IMAGE]', 'Docker image for npm install', DOCKER_IMAGE)
+  .option('-I, --dockerImage [DOCKER_IMAGE]', 'Docker image for npm ci', DOCKER_IMAGE)
   .option('-f, --configFile [CONFIG_FILE]',
     'Path to file holding secret environment variables (e.g. "deploy.env")', CONFIG_FILE)
   .option('-S, --eventSourceFile [EVENT_SOURCE_FILE]',
@@ -114,7 +114,7 @@ program
   .alias('zip')
   .description('Create zipped package for Amazon Lambda deployment')
   .option('-A, --packageDirectory [PACKAGE_DIRECTORY]', 'Local Package Directory', PACKAGE_DIRECTORY)
-  .option('-I, --dockerImage [DOCKER_IMAGE]', 'Docker image for npm install', DOCKER_IMAGE)
+  .option('-I, --dockerImage [DOCKER_IMAGE]', 'Docker image for npm ci', DOCKER_IMAGE)
   .option('-n, --functionName [AWS_FUNCTION_NAME]', 'Lambda FunctionName', AWS_FUNCTION_NAME)
   .option('-H, --handler [AWS_HANDLER]', 'Lambda Handler {index.handler}', AWS_HANDLER)
   .option('-e, --environment [AWS_ENVIRONMENT]', 'Choose environment {dev, staging, production}',

--- a/lib/main.js
+++ b/lib/main.js
@@ -628,7 +628,7 @@ they may not work as expected in the Lambda environment.
       if (program.keepNodeModules) {
         return Promise.resolve()
       } else {
-        console.log('=> Running npm install --production')
+        console.log('=> Running npm ci --production')
         return this._npmInstall(program, codeDirectory)
       }
     }).then(() => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -344,8 +344,12 @@ so you can easily test run multiple events.
     })
   }
 
+  _shouldUseNpmCi (codeDirectory) {
+    return fs.existsSync(path.join(codeDirectory, 'package-lock.json'))
+  }
+
   _npmInstall (program, codeDirectory) {
-    const installCommand = fs.existsSync(path.join(codeDirectory, 'package-lock.json'))
+    const installCommand = this._shouldUseNpmCi(codeDirectory)
       ? 'ci'
       : 'install'
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -345,6 +345,10 @@ so you can easily test run multiple events.
   }
 
   _npmInstall (program, codeDirectory) {
+    const installCommand = fs.existsSync(path.join(codeDirectory, 'package-lock.json'))
+      ? 'ci'
+      : 'install'
+
     const dockerBaseOptions = [
       'run', '--rm',
       '-v', `${fs.realpathSync(codeDirectory)}:/var/task`,
@@ -356,13 +360,13 @@ so you can easily test run multiple events.
       dockerVolumesOptions = dockerVolumesOptions.concat(['-v', volume])
     })
 
-    const dockerCommand = [program.dockerImage, 'npm', '-s', 'ci', '--production']
+    const dockerCommand = [program.dockerImage, 'npm', '-s', installCommand, '--production']
 
     const dockerOptions = dockerBaseOptions.concat(dockerVolumesOptions).concat(dockerCommand)
 
     const npmInstallBaseOptions = [
       '-s',
-      'ci',
+      installCommand,
       '--production',
       '--prefix', codeDirectory
     ]

--- a/lib/main.js
+++ b/lib/main.js
@@ -356,13 +356,13 @@ so you can easily test run multiple events.
       dockerVolumesOptions = dockerVolumesOptions.concat(['-v', volume])
     })
 
-    const dockerCommand = [program.dockerImage, 'npm', '-s', 'install', '--production']
+    const dockerCommand = [program.dockerImage, 'npm', '-s', 'ci', '--production']
 
     const dockerOptions = dockerBaseOptions.concat(dockerVolumesOptions).concat(dockerCommand)
 
     const npmInstallBaseOptions = [
       '-s',
-      'install',
+      'ci',
       '--production',
       '--prefix', codeDirectory
     ]

--- a/lib/main.js
+++ b/lib/main.js
@@ -321,8 +321,8 @@ so you can easily test run multiple events.
         const options = {
           dereference: true, // same meaning as `-L` of `rsync` command
           filter: (src, dest) => {
-            if (!program.prebuiltDirectory && src === 'package.json') {
-              // include package.json unless prebuiltDirectory is set
+            if (!program.prebuiltDirectory && ['package.json', 'package-lock.json'].includes(src)) {
+              // include package.json & package-lock.json unless prebuiltDirectory is set
               return true
             }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -636,7 +636,7 @@ they may not work as expected in the Lambda environment.
       if (program.keepNodeModules) {
         return Promise.resolve()
       } else {
-        console.log('=> Running npm ci --production')
+        console.log(`=> Running npm ${this._shouldUseNpmCi(codeDirectory) ? 'ci' : 'install'} --production`)
         return this._npmInstall(program, codeDirectory)
       }
     }).then(() => {

--- a/test/main.js
+++ b/test/main.js
@@ -544,7 +544,7 @@ describe('lib/main', function () {
         return lambda._npmInstall(program, codeDirectory).then(() => {
           const contents = fs.readdirSync(codeDirectory)
           assert.include(contents, 'node_modules')
-          assert.isNotTrue(fs.existsSync(nodeModulesFile))
+          assert.isFalse(fs.existsSync(nodeModulesFile))
         })
       })
     })

--- a/test/main.js
+++ b/test/main.js
@@ -556,8 +556,7 @@ describe('lib/main', function () {
 
     beforeEach(() => {
       return lambda._cleanDirectory(codeDirectory).then(() => {
-        // put our own file in node_modules so we can verify installs
-        fs.mkdirSync(path.join(codeDirectory, 'node_modules'))
+        // hide our own file in node_modules to verify installs
         fs.ensureFileSync(nodeModulesFile)
 
         return lambda._fileCopy(program, '.', codeDirectory, true)

--- a/test/main.js
+++ b/test/main.js
@@ -576,7 +576,7 @@ describe('lib/main', function () {
     })
     describe('when package-lock.json does not exist', () => {
       beforeEach(() => {
-        fs.removeSync(path.join(codeDirectory, 'package-lock.json'))
+        return fs.removeSync(path.join(codeDirectory, 'package-lock.json'))
       })
 
       it('should use "npm install"', function () {

--- a/test/main.js
+++ b/test/main.js
@@ -497,6 +497,13 @@ describe('lib/main', function () {
           assert.include(contents, 'package.json')
         })
       })
+      it('_fileCopy should not exclude package-lock.json, even when excluded by excludeGlobs', () => {
+        program.excludeGlobs = '*.json'
+        return lambda._fileCopy(program, '.', codeDirectory, true).then(() => {
+          const contents = fs.readdirSync(codeDirectory)
+          assert.include(contents, 'package-lock.json')
+        })
+      })
 
       it('_fileCopy should not include package.json when --prebuiltDirectory is set', () => {
         const buildDir = '.build_' + Date.now()

--- a/test/main.js
+++ b/test/main.js
@@ -564,7 +564,7 @@ describe('lib/main', function () {
     })
 
     describe('when package-lock.json does exist', () => {
-      it('should use "npm ci"', () => {
+      it('should use "npm ci"', function () {
         _timeout({ this: this, sec: 30 }) // ci should be faster than install
 
         return lambda._npmInstall(program, codeDirectory).then(() => {
@@ -579,7 +579,7 @@ describe('lib/main', function () {
         fs.removeSync(path.join(codeDirectory, 'package-lock.json'))
       })
 
-      it('should use "npm install"', () => {
+      it('should use "npm install"', function () {
         _timeout({ this: this, sec: 60 }) // install should be slower than ci
 
         return lambda._npmInstall(program, codeDirectory).then(() => {

--- a/test/main.js
+++ b/test/main.js
@@ -563,8 +563,8 @@ describe('lib/main', function () {
       })
     })
 
-    describe('when there is a package-lock.json', () => {
-      it('should use "ci"', () => {
+    describe('when package-lock.json does exist', () => {
+      it('should use "npm ci"', () => {
         _timeout({ this: this, sec: 30 }) // ci should be faster than install
 
         return lambda._npmInstall(program, codeDirectory).then(() => {
@@ -574,12 +574,12 @@ describe('lib/main', function () {
         })
       })
     })
-    describe('when there is no package-lock.json', () => {
+    describe('when package-lock.json does not exist', () => {
       beforeEach(() => {
         fs.removeSync(path.join(codeDirectory, 'package-lock.json'))
       })
 
-      it('should use "install"', () => {
+      it('should use "npm install"', () => {
         _timeout({ this: this, sec: 60 }) // install should be slower than ci
 
         return lambda._npmInstall(program, codeDirectory).then(() => {

--- a/test/main.js
+++ b/test/main.js
@@ -524,6 +524,32 @@ describe('lib/main', function () {
     })
   })
 
+  describe('_shouldUseNpmCi', () => {
+    beforeEach(() => {
+      return lambda._cleanDirectory(codeDirectory)
+    })
+
+    describe('when package-lock.json exists', () => {
+      beforeEach(() => {
+        fs.writeFileSync(path.join(codeDirectory, 'package-lock.json'), JSON.stringify({}))
+      })
+
+      it('returns true', () => {
+        assert.isTrue(lambda._shouldUseNpmCi(codeDirectory))
+      })
+    })
+
+    describe('when package-lock.json does not exist', () => {
+      beforeEach(() => {
+        fs.removeSync(path.join(codeDirectory, 'package-lock.json'))
+      })
+
+      it('returns false', () => {
+        assert.isFalse(lambda._shouldUseNpmCi(codeDirectory))
+      })
+    })
+  })
+
   describe('_npmInstall', () => {
     const nodeModulesFile = path.join(codeDirectory, 'node_modules', 'file')
 

--- a/test/main.js
+++ b/test/main.js
@@ -551,13 +551,14 @@ describe('lib/main', function () {
   })
 
   describe('_npmInstall', () => {
-    const nodeModulesFile = path.join(codeDirectory, 'node_modules', 'file')
+    // npm treats files as packages when installing, and so removes them - hence hide in .bin
+    const nodeModulesFile = path.join(codeDirectory, 'node_modules', '.bin', 'file')
 
     beforeEach(() => {
       return lambda._cleanDirectory(codeDirectory).then(() => {
         // put our own file in node_modules so we can verify installs
         fs.mkdirSync(path.join(codeDirectory, 'node_modules'))
-        fs.writeFileSync(nodeModulesFile, 'hello world')
+        fs.ensureFileSync(nodeModulesFile)
 
         return lambda._fileCopy(program, '.', codeDirectory, true)
       })


### PR DESCRIPTION
`npm ci` installs the version of packages solely based on what's in the `package-lock.json`, making it faster since it doesn't need to resolve the versions of packages, and also ensures it installs the same package version every time.