### PR TITLE
Don't audit packages when installing

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -364,7 +364,7 @@ so you can easily test run multiple events.
       dockerVolumesOptions = dockerVolumesOptions.concat(['-v', volume])
     })
 
-    const dockerCommand = [program.dockerImage, 'npm', '-s', installCommand, '--production']
+    const dockerCommand = [program.dockerImage, 'npm', '-s', installCommand, '--production', '--no-audit']
 
     const dockerOptions = dockerBaseOptions.concat(dockerVolumesOptions).concat(dockerCommand)
 
@@ -372,6 +372,7 @@ so you can easily test run multiple events.
       '-s',
       installCommand,
       '--production',
+      '--no-audit',
       '--prefix', codeDirectory
     ]
 


### PR DESCRIPTION
Since the install output doesn't get seen, auditing has no purpose - this technically makes installing a little "faster" b/c it's not having to scan all the packages and make an http request.