### PR TITLE
Fix GitHub Actions workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,6 +1,6 @@
 name: Node CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,5 +16,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm i -g npm
-    - run: npm install
+    - run: node -v
+    - run: npm -v
+    - run: npm ci
     - run: npm test

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,10 +12,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@master
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@master
       with:
         node-version: ${{ matrix.node-version }}
-    - name: npm install, and test
-      run: |
-        npm install
-        npm test
+    - run: npm i -g npm
+    - run: npm install
+    - run: npm test


### PR DESCRIPTION
* Fix 'run' of GitHub Actions workflow.
    * Fix because it was not working properly on Windows.
* Add 'pull_request' to GitHub Actions event
* Modify GitHub Actions setting from 'npm install' to 'npm ci'
* Add confirmation of node and npm versions