### PR TITLE
Remove 'osx' from travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: node_js
-os:
-  - linux
-  - osx
 
 node_js:
-  - 8
-  - 10
-  - 12
+  - "lts/*"
+  - "node"
 
 cache:
   directories:
@@ -15,7 +11,7 @@ cache:
 jobs:
   include:
     - stage: npm release
-      node_js: 10
+      node_js: node
       script: echo "Deploying to npm ..."
       deploy:
         provider: npm


### PR DESCRIPTION
* Mac tests run at GitHub Actions.
* Improve node version specification.
    * https://medium.com/@nodejs/choosing-the-node-js-versions-for-your-ci-tests-hint-use-lts-89b67f68d7ca#5e43
    * Since GitHub Actions is also testing, `node` and `lts/*` are specified.