### PR TITLE
Drop nodejs8.10 from runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ AWS Lambda will let you set environment variables for your function. Use the sam
 
 ## Node.js Runtime Configuration
 
-AWS Lambda now supports Node.js 12, Node.js 10 and Node.js 8.10. Please also check the [Programming Model (Node.js)](http://docs.aws.amazon.com/lambda/latest/dg/programming-model.html) page.
+AWS Lambda now supports Node.js 12 and Node.js 10. Please also check the [Programming Model (Node.js)](http://docs.aws.amazon.com/lambda/latest/dg/programming-model.html) page.
 
 ## Post install script
 When running `node-lambda deploy` if you need to do some action after `npm install --production` and before deploying to AWS Lambda (e.g. replace some modules with precompiled ones or download some libraries, replace some config file depending on environment) you can create `post_install.sh` script. If the file exists the script will be executed (and output shown after execution) if not it is skipped. Environment string is passed to script as first parameter so you can use it if needed. Make sure that the script is executable.

--- a/lib/main.js
+++ b/lib/main.js
@@ -51,7 +51,7 @@ event_sources.json and ${program.eventFile} files as needed.`)
   }
 
   run (program) {
-    if (!['nodejs8.10', 'nodejs10.x', 'nodejs12.x'].includes(program.runtime)) {
+    if (!['nodejs10.x', 'nodejs12.x'].includes(program.runtime)) {
       console.error(`Runtime [${program.runtime}] is not supported.`)
       process.exit(254)
     }


### PR DESCRIPTION
`nodejs8.10`

* Deprecation (Create): January 6, 2020
* Deprecation (Update): February 3, 2020

https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html