### PR TITLE
Clean the tmp directory during _archivePrebuilt to match _buildAndArchive behavior

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -613,9 +613,13 @@ so you can easily test run multiple events.
   _archivePrebuilt (program) {
     const codeDirectory = this._codeDirectory()
 
-    return this._fileCopy(program, program.prebuiltDirectory, codeDirectory, false).then(() => {
-      console.log('=> Zipping deployment package')
-      return this._zip(program, codeDirectory)
+    return Promise.resolve().then(() => {
+      return this._cleanDirectory(codeDirectory, program.keepNodeModules)
+    }).then(() => {
+      return this._fileCopy(program, program.prebuiltDirectory, codeDirectory, false).then(() => {
+        console.log('=> Zipping deployment package')
+        return this._zip(program, codeDirectory)
+      })
     })
   }
 

--- a/test/main.js
+++ b/test/main.js
@@ -775,6 +775,24 @@ describe('lib/main', function () {
         })
       })
     })
+
+    it('cleans the temporary directory before running `_archivePrebuilt`', function () {
+      _timeout({ this: this, sec: 30 }) // give it time to zip
+      const buildDir = '.build_' + Date.now()
+      const codeDir = lambda._codeDirectory()
+      const tmpFile = path.join(codeDir, 'deleteme')
+      after(() => fs.removeSync(buildDir))
+
+      fs.mkdirSync(codeDir, { recursive: true })
+      fs.writeFileSync(tmpFile, '...')
+      fs.mkdirSync(buildDir)
+      fs.writeFileSync(path.join(buildDir, 'test'), '...')
+
+      program.prebuiltDirectory = buildDir
+      return lambda._archive(program).then((_data) => {
+        assert.isNotTrue(fs.existsSync(tmpFile))
+      })
+    })
   })
 
   describe('_readArchive', () => {


### PR DESCRIPTION
I recently noticed an issue where if `prebuiltDirectory` was set, the zip file generated by `node-lambda package` would include files I had already deleted from my source. Turns out it was combining the output of the current run with the contents of earlier runs. The fix is to clean the `_codeDirectory()` before writing to it, which matches the existing `node-lambda package` behavior when `prebuiltDirectory` is not set.

Other than running the unit tests, I tested the changes in my project and verified that the temp directory is emptied between runs.