### PR TITLE
Add Silent or quiet mode when deploying

### DIFF
--- a/bin/node-lambda
+++ b/bin/node-lambda
@@ -107,7 +107,13 @@ program
   .option('-B, --deployUseS3 [DEPLOY_USE_S3]', 'Use S3 to deploy.', DEPLOY_USE_S3)
   .option('-y, --proxy [PROXY]', 'Proxy server', PROXY)
   .option('-A, --tags [AWS_TAGS]', 'Tags as key value pairs (e.g. "tagname1=tagvalue1,tagname2=tagvalue2)"', AWS_TAGS)
-  .action((prg) => lambda.deploy(prg))
+  .option('--silent', 'Silent  or  quiet mode', false)
+  .action((prg) => {
+    if (prg.silent) {
+      console.log = () => {}
+    }
+    lambda.deploy(prg)
+  })
 
 program
   .command('package')


### PR DESCRIPTION
fix #519 

Disabled console.log and suppressed all output.
Is it better to suppress only output that includes environment variables?