### PR TITLE
Add Node.js 14 to CI settings

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@master

--- a/test/main.js
+++ b/test/main.js
@@ -414,9 +414,9 @@ describe('lib/main', function () {
       fs.mkdirSync('build')
       fs.mkdirsSync(path.join('__unittest', 'hoge'))
       fs.mkdirsSync(path.join('__unittest', 'fuga'))
-      fs.writeFileSync(path.join('__unittest', 'hoge', 'piyo'))
-      fs.writeFileSync(path.join('__unittest', 'hoge', 'package.json'))
-      fs.writeFileSync('fuga')
+      fs.writeFileSync(path.join('__unittest', 'hoge', 'piyo'), '')
+      fs.writeFileSync(path.join('__unittest', 'hoge', 'package.json'), '')
+      fs.writeFileSync('fuga', '')
     })
     after(() => {
       ['build', 'fuga', '__unittest'].forEach((path) => {
@@ -504,8 +504,8 @@ describe('lib/main', function () {
         after(() => fs.removeSync(buildDir))
 
         fs.mkdirSync(buildDir)
-        fs.writeFileSync(path.join(buildDir, 'testa'))
-        fs.writeFileSync(path.join(buildDir, 'package.json'))
+        fs.writeFileSync(path.join(buildDir, 'testa'), '')
+        fs.writeFileSync(path.join(buildDir, 'package.json'), '')
 
         program.excludeGlobs = '*.json'
         program.prebuiltDirectory = buildDir


### PR DESCRIPTION
The test failed in Node.js14, so I fixed it.

The following error in Node.js14.

```
     TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined
      at Object.writeFileSync (fs.js:1380:5)
      at Context.<anonymous> (test/main.js:417:10)
      at processImmediate (internal/timers.js:456:21)
      at process.topLevelDomainCallback (domain.js:137:15)
```