### PR TITLE
ci: add 'fail-fast: false' setting

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,6 +7,7 @@ jobs:
     name: Test on node ${{ matrix.node-version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         node-version: [10.x, 12.x, 14.x]
         os: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
There are tests that fail in time out.
This is because we want to run all the tests even in that case.