### PR TITLE
feat: support for 'ImageUri' parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,8 @@ node_modules
 !.env.example
 .env
 event.json
+context.json
+deploy.env
+event_sources.json
 npm-debug.log*
 .lambda

--- a/bin/node-lambda
+++ b/bin/node-lambda
@@ -59,6 +59,7 @@ const ENABLE_RUN_MULTIPLE_EVENTS = true
 const KEEP_NODE_MODULES = process.env.KEEP_NODE_MODULES || false
 const DOCKER_VOLUMES = process.env.DOCKER_VOLUMES || ''
 const AWS_TAGS = process.env.AWS_TAGS || ''
+const IMAGE_URI = process.env.IMAGE_URI || ''
 
 program
   .command('deploy')
@@ -104,6 +105,7 @@ program
   .option('-T, --deployTimeout [DEPLOY_TIMEOUT]', 'Deploy Timeout', DEPLOY_TIMEOUT)
   .option('-z, --deployZipfile [DEPLOY_ZIPFILE]', 'Deploy zipfile', DEPLOY_ZIPFILE)
   .option('-B, --deployUseS3 [DEPLOY_USE_S3]', 'Use S3 to deploy.', DEPLOY_USE_S3)
+  .option('-i, --imageUri [IMAGE_URI]', 'URI of a container image in the Amazon ECR registry.', IMAGE_URI)
   .option('-y, --proxy [PROXY]', 'Proxy server', PROXY)
   .option('-A, --tags [AWS_TAGS]', 'Tags as key value pairs (e.g. "tagname1=tagvalue1,tagname2=tagvalue2)"', AWS_TAGS)
   .option('--silent', 'Silent  or  quiet mode', false)

--- a/lib/main.js
+++ b/lib/main.js
@@ -199,6 +199,10 @@ Emulate only the body of the API Gateway event.
     return program.deployUseS3 === 'true'
   }
 
+  _useECR (program) {
+    return program.imageUri != null && program.imageUri.length > 0
+  }
+
   _params (program, buffer) {
     const params = {
       FunctionName: program.functionName +
@@ -232,7 +236,8 @@ Emulate only the body of the API Gateway event.
         Mode: null
       },
       Layers: [],
-      Tags: {}
+      Tags: {},
+      PackageType: 'Zip'
     }
 
     if (this._isUseS3(program)) {
@@ -240,6 +245,12 @@ Emulate only the body of the API Gateway event.
         S3Bucket: null,
         S3Key: null
       }
+    } else if (this._useECR(program)) {
+      params.Code = { ImageUri: program.imageUri }
+      params.PackageType = 'Image'
+      delete params.Handler
+      delete params.Runtime
+      delete params.KMSKeyArn
     } else {
       params.Code = { ZipFile: buffer }
     }
@@ -556,39 +567,50 @@ Emulate only the body of the API Gateway event.
   }
 
   _uploadExisting (lambda, params) {
-    const _params = Object.assign({
+    const functionCodeParams = Object.assign({
       FunctionName: params.FunctionName,
       Publish: params.Publish
     }, params.Code)
 
+    const functionConfigParams = {
+      FunctionName: params.FunctionName,
+      Description: params.Description,
+      Handler: params.Handler,
+      MemorySize: params.MemorySize,
+      Role: params.Role,
+      Timeout: params.Timeout,
+      Runtime: params.Runtime,
+      VpcConfig: params.VpcConfig,
+      Environment: params.Environment,
+      KMSKeyArn: params.KMSKeyArn,
+      DeadLetterConfig: params.DeadLetterConfig,
+      TracingConfig: params.TracingConfig,
+      Layers: params.Layers
+    }
+    if (functionCodeParams.ImageUri != null) {
+      delete functionConfigParams.Handler
+      delete functionConfigParams.Runtime
+      delete functionConfigParams.KMSKeyArn
+      delete functionConfigParams.Layers
+    }
+
     return new Promise((resolve, reject) => {
-      const updateConfigRequest = lambda.updateFunctionConfiguration({
-        FunctionName: params.FunctionName,
-        Description: params.Description,
-        Handler: params.Handler,
-        MemorySize: params.MemorySize,
-        Role: params.Role,
-        Timeout: params.Timeout,
-        Runtime: params.Runtime,
-        VpcConfig: params.VpcConfig,
-        Environment: params.Environment,
-        KMSKeyArn: params.KMSKeyArn,
-        DeadLetterConfig: params.DeadLetterConfig,
-        TracingConfig: params.TracingConfig,
-        Layers: params.Layers
-      }, (err, configResponse) => {
-        if (err) return reject(err)
-
-        const updateCodeRequest = lambda.updateFunctionCode(_params, (err) => {
+      const updateConfigRequest = lambda.updateFunctionConfiguration(
+        functionConfigParams,
+        (err, configResponse) => {
           if (err) return reject(err)
-          resolve(configResponse)
-        })
 
-        updateCodeRequest.on('retry', (response) => {
-          console.log(response.error.message)
-          console.log('=> Retrying')
-        })
-      })
+          const updateCodeRequest = lambda.updateFunctionCode(functionCodeParams, (err) => {
+            if (err) return reject(err)
+            resolve(configResponse)
+          })
+
+          updateCodeRequest.on('retry', (response) => {
+            console.log(response.error.message)
+            console.log('=> Retrying')
+          })
+        }
+      )
 
       updateConfigRequest.on('retry', (response) => {
         console.log(response.error.message)
@@ -1009,28 +1031,35 @@ they may not work as expected in the Lambda environment.
     })
   }
 
-  deploy (program) {
+  async deploy (program) {
     const regions = program.region.split(',')
-    return this._archive(program).then((buffer) => {
-      console.log('=> Reading zip file to memory')
-      return buffer
-    }).then((buffer) => {
-      const params = this._params(program, buffer)
+    let buffer = null
+    if (!this._useECR(program)) {
+      try {
+        buffer = await this._archive(program)
+        console.log('=> Reading zip file to memory')
+      } catch (err) {
+        process.exitCode = 1
+        console.log(err)
+        return
+      }
+    }
 
-      return Promise.all(regions.map((region) => {
+    try {
+      const params = this._params(program, buffer)
+      const results = await Promise.all(regions.map((region) => {
         return this._deployToRegion(
           program,
           params,
           region,
           this._isUseS3(program) ? buffer : null
         )
-      })).then(results => {
-        this._printDeployResults(results, true)
-      })
-    }).catch((err) => {
+      }))
+      this._printDeployResults(results, true)
+    } catch (err) {
       process.exitCode = 1
       console.log(err)
-    })
+    }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -333,9 +333,9 @@
       "integrity": "sha1-0WkB0QzOxZUWwZe5zNiTBom4E7Q="
     },
     "aws-sdk": {
-      "version": "2.724.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.724.0.tgz",
-      "integrity": "sha512-XfTPfNAkpLn/RE9ODMs8PDoZ1cI5npeS4p452mDKWUGqdr8DthdQ+6QU786KSzBRB9Bs+k5MCXI62Nv//aLFZA==",
+      "version": "2.831.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.831.0.tgz",
+      "integrity": "sha512-lrOjbGFpjk2xpESyUx2PGsTZgptCy5xycZazPeakNbFO19cOoxjHx3xyxOHsMCYb3pQwns35UvChQT60B4u6cw==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "archiver": "^5.0.0",
-    "aws-sdk": "^2.724.0",
+    "aws-sdk": "^2.831.0",
     "aws-xray-sdk-core": "^3.1.0",
     "commander": "^7.0.0",
     "continuation-local-storage": "^3.2.1",

--- a/test/main.js
+++ b/test/main.js
@@ -205,6 +205,22 @@ describe('lib/main', function () {
     })
   })
 
+  describe('_useECR', () => {
+    it('=== true', () => {
+      assert.isTrue(lambda._useECR({ imageUri: 'xxx' }))
+    })
+
+    it('=== false', () => {
+      [
+        {},
+        { imageUri: null },
+        { imageUri: '' }
+      ].forEach((params) => {
+        assert.isFalse(lambda._useECR(params), params)
+      })
+    })
+  })
+
   describe('_params', () => {
     // http://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-FunctionName
     const functionNamePattern =
@@ -322,6 +338,32 @@ describe('lib/main', function () {
             S3Bucket: null,
             S3Key: null
           }
+        )
+      })
+    })
+
+    describe('PackageType: Zip|Image', () => {
+      it('PackageType: Zip', () => {
+        const params = lambda._params(program, 'Buffer')
+        assert.equal(params.PackageType, 'Zip')
+        assert.deepEqual(
+          params.Code,
+          { ZipFile: 'Buffer' }
+        )
+      })
+
+      it('PackageType: Image', () => {
+        program.imageUri = 'xxx'
+        const params = lambda._params(program, 'Buffer')
+        assert.equal(params.PackageType, 'Image')
+
+        assert.isUndefined(params.Handler)
+        assert.isUndefined(params.Runtime)
+        assert.isUndefined(params.KMSKeyArn)
+
+        assert.deepEqual(
+          params.Code,
+          { ImageUri: 'xxx' }
         )
       })
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -323,10 +323,25 @@ aws-sdk-mock@^5.1.0:
     sinon "^9.0.1"
     traverse "^0.6.6"
 
-aws-sdk@^2.637.0, aws-sdk@^2.724.0:
+aws-sdk@^2.637.0:
   version "2.724.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.724.0.tgz#30e18c62930a17b5b0b5ec43f53e82996008b54d"
   integrity sha512-XfTPfNAkpLn/RE9ODMs8PDoZ1cI5npeS4p452mDKWUGqdr8DthdQ+6QU786KSzBRB9Bs+k5MCXI62Nv//aLFZA==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
+aws-sdk@^2.831.0:
+  version "2.831.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.831.0.tgz#02607cc911a2136e5aabe624c1282e821830aef2"
+  integrity sha512-lrOjbGFpjk2xpESyUx2PGsTZgptCy5xycZazPeakNbFO19cOoxjHx3xyxOHsMCYb3pQwns35UvChQT60B4u6cw==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
* Upgraded to aws-sdk with `ImageUri` available.
* `ImageUri` is now supported.
* Push to ECR is not implemented.

This is not related to the main topic, but the files created by `node-lambda setup` have been added to .gitignore.