### PR TITLE
bump to 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -421,3 +421,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Upgrade packages [#538](https://github.com/motdotla/node-lambda/pull/538)
 - Bump lodash from 4.17.15 to 4.17.19 [#536](https://github.com/motdotla/node-lambda/pull/536)
 - Add build badge in README [#534](https://github.com/motdotla/node-lambda/pull/534)
+
+## [0.19.0] - 2021-03-30
+### Features
+- feat: support `--no-optional` option in npm install [#557](https://github.com/motdotla/node-lambda/pull/557)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lambda",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lambda",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Command line tool for locally running and remotely deploying your node.js applications to Amazon Lambda.",
   "main": "lib/main.js",
   "directories": {

--- a/test/main.js
+++ b/test/main.js
@@ -149,7 +149,7 @@ describe('lib/main', function () {
   })
 
   it('version should be set', () => {
-    assert.equal(lambda.version, '0.18.0')
+    assert.equal(lambda.version, '0.19.0')
   })
 
   describe('_codeDirectory', () => {


### PR DESCRIPTION
### Features
- feat: support `--no-optional` option in npm install [#557](https://github.com/motdotla/node-lambda/pull/557)