### PR TITLE
feat: drop nodejs10x from lambda runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ AWS Lambda will let you set environment variables for your function. Use the sam
 
 ## Node.js Runtime Configuration
 
-AWS Lambda now supports Node.js14, Node.js 12 and Node.js 10. Please also check the [Building Lambda functions with Node.js](https://docs.aws.amazon.com/lambda/latest/dg/lambda-nodejs.html) page.
+AWS Lambda now supports Node.js14 and Node.js 12. Please also check the [Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) page.
 
 ## To deploy a container image to Lambda
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -51,7 +51,7 @@ event_sources.json and ${program.eventFile} files as needed.`)
   }
 
   run (program) {
-    if (!['nodejs10.x', 'nodejs12.x', 'nodejs14.x'].includes(program.runtime)) {
+    if (!['nodejs12.x', 'nodejs14.x'].includes(program.runtime)) {
       console.error(`Runtime [${program.runtime}] is not supported.`)
       process.exit(254)
     }


### PR DESCRIPTION
nodejs10x will be dropped as it is no longer supported soon.
https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html