### PR TITLE
updated proxy-agent to 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "node-lambda",
       "version": "0.19.1",
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -18,7 +17,7 @@
         "fs-extra": "^10.0.0",
         "klaw": "^3.0.0",
         "minimatch": "^3.0.4",
-        "proxy-agent": "^4.0.1"
+        "proxy-agent": "^5.0.0"
       },
       "bin": {
         "node-lambda": "bin/node-lambda"
@@ -1079,13 +1078,14 @@
       }
     },
     "node_modules/degenerator": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-2.2.0.tgz",
-      "integrity": "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-3.0.1.tgz",
+      "integrity": "sha512-LFsIFEeLPlKvAKXu7j3ssIG6RT0TbI7/GhsqrI0DnHASEQjXQ0LUSYcjJteGgRGmZbl1TnMSxpNQIAiJ7Du5TQ==",
       "dependencies": {
         "ast-types": "^0.13.2",
         "escodegen": "^1.8.1",
-        "esprima": "^4.0.0"
+        "esprima": "^4.0.0",
+        "vm2": "^3.9.3"
       },
       "engines": {
         "node": ">= 6"
@@ -3096,9 +3096,9 @@
       }
     },
     "node_modules/pac-proxy-agent": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-4.1.0.tgz",
-      "integrity": "sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-CcFG3ZtnxO8McDigozwE3AqAw15zDvGH+OjXO4kzf7IkEKkQ4gxQ+3sdF50WmhQ4P/bVusXcqNE2S3XrNURwzQ==",
       "dependencies": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -3106,25 +3106,25 @@
         "get-uri": "3",
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "5",
-        "pac-resolver": "^4.1.0",
+        "pac-resolver": "^5.0.0",
         "raw-body": "^2.2.0",
         "socks-proxy-agent": "5"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 8"
       }
     },
     "node_modules/pac-resolver": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.2.0.tgz",
-      "integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-5.0.0.tgz",
+      "integrity": "sha512-H+/A6KitiHNNW+bxBKREk2MCGSxljfqRX76NjummWEYIat7ldVXRU3dhRIE3iXZ0nvGBk6smv3nntxKkzRL8NA==",
       "dependencies": {
-        "degenerator": "^2.2.0",
+        "degenerator": "^3.0.1",
         "ip": "^1.1.5",
         "netmask": "^2.0.1"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 8"
       }
     },
     "node_modules/pako": {
@@ -3492,21 +3492,21 @@
       }
     },
     "node_modules/proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-gkH7BkvLVkSfX9Dk27W6TyNOWWZWRilRfk1XxGNWOYJ2TuedAv1yFpCaU9QSBmBe716XOTNpYNOzhysyw8xn7g==",
       "dependencies": {
         "agent-base": "^6.0.0",
         "debug": "4",
         "http-proxy-agent": "^4.0.0",
         "https-proxy-agent": "^5.0.0",
         "lru-cache": "^5.1.1",
-        "pac-proxy-agent": "^4.1.0",
+        "pac-proxy-agent": "^5.0.0",
         "proxy-from-env": "^1.0.0",
         "socks-proxy-agent": "^5.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">= 8"
       }
     },
     "node_modules/proxy-agent/node_modules/lru-cache": {
@@ -3942,9 +3942,9 @@
       "dev": true
     },
     "node_modules/smart-buffer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -4312,9 +4312,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4428,6 +4428,17 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vm2": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.3.tgz",
+      "integrity": "sha512-smLS+18RjXYMl9joyJxMNI9l4w7biW8ilSDaVRvFBDwOH8P0BK1ognFQTpg0wyQ6wIKLTblHJvROW692L/E53Q==",
+      "bin": {
+        "vm2": "bin/vm2"
+      },
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/which": {
@@ -5541,13 +5552,14 @@
       }
     },
     "degenerator": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-2.2.0.tgz",
-      "integrity": "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-3.0.1.tgz",
+      "integrity": "sha512-LFsIFEeLPlKvAKXu7j3ssIG6RT0TbI7/GhsqrI0DnHASEQjXQ0LUSYcjJteGgRGmZbl1TnMSxpNQIAiJ7Du5TQ==",
       "requires": {
         "ast-types": "^0.13.2",
         "escodegen": "^1.8.1",
-        "esprima": "^4.0.0"
+        "esprima": "^4.0.0",
+        "vm2": "^3.9.3"
       }
     },
     "depd": {
@@ -7057,9 +7069,9 @@
       "dev": true
     },
     "pac-proxy-agent": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-4.1.0.tgz",
-      "integrity": "sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-CcFG3ZtnxO8McDigozwE3AqAw15zDvGH+OjXO4kzf7IkEKkQ4gxQ+3sdF50WmhQ4P/bVusXcqNE2S3XrNURwzQ==",
       "requires": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -7067,17 +7079,17 @@
         "get-uri": "3",
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "5",
-        "pac-resolver": "^4.1.0",
+        "pac-resolver": "^5.0.0",
         "raw-body": "^2.2.0",
         "socks-proxy-agent": "5"
       }
     },
     "pac-resolver": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.2.0.tgz",
-      "integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-5.0.0.tgz",
+      "integrity": "sha512-H+/A6KitiHNNW+bxBKREk2MCGSxljfqRX76NjummWEYIat7ldVXRU3dhRIE3iXZ0nvGBk6smv3nntxKkzRL8NA==",
       "requires": {
-        "degenerator": "^2.2.0",
+        "degenerator": "^3.0.1",
         "ip": "^1.1.5",
         "netmask": "^2.0.1"
       }
@@ -7357,16 +7369,16 @@
       }
     },
     "proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-gkH7BkvLVkSfX9Dk27W6TyNOWWZWRilRfk1XxGNWOYJ2TuedAv1yFpCaU9QSBmBe716XOTNpYNOzhysyw8xn7g==",
       "requires": {
         "agent-base": "^6.0.0",
         "debug": "4",
         "http-proxy-agent": "^4.0.0",
         "https-proxy-agent": "^5.0.0",
         "lru-cache": "^5.1.1",
-        "pac-proxy-agent": "^4.1.0",
+        "pac-proxy-agent": "^5.0.0",
         "proxy-from-env": "^1.0.0",
         "socks-proxy-agent": "^5.0.0"
       },
@@ -7706,9 +7718,9 @@
       }
     },
     "smart-buffer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
     },
     "socks": {
       "version": "2.6.1",
@@ -7976,9 +7988,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "type-check": {
       "version": "0.4.0",
@@ -8073,6 +8085,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "vm2": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.3.tgz",
+      "integrity": "sha512-smLS+18RjXYMl9joyJxMNI9l4w7biW8ilSDaVRvFBDwOH8P0BK1ognFQTpg0wyQ6wIKLTblHJvROW692L/E53Q=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "fs-extra": "^10.0.0",
     "klaw": "^3.0.0",
     "minimatch": "^3.0.4",
-    "proxy-agent": "^4.0.1"
+    "proxy-agent": "^5.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -622,14 +622,15 @@
   dependencies:
     "object-keys" "^1.0.12"
 
-"degenerator@^2.2.0":
-  "integrity" "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg=="
-  "resolved" "https://registry.npmjs.org/degenerator/-/degenerator-2.2.0.tgz"
-  "version" "2.2.0"
+"degenerator@^3.0.1":
+  "integrity" "sha512-LFsIFEeLPlKvAKXu7j3ssIG6RT0TbI7/GhsqrI0DnHASEQjXQ0LUSYcjJteGgRGmZbl1TnMSxpNQIAiJ7Du5TQ=="
+  "resolved" "https://registry.npmjs.org/degenerator/-/degenerator-3.0.1.tgz"
+  "version" "3.0.1"
   dependencies:
     "ast-types" "^0.13.2"
     "escodegen" "^1.8.1"
     "esprima" "^4.0.0"
+    "vm2" "^3.9.3"
 
 "depd@~1.1.2":
   "integrity" "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
@@ -1907,10 +1908,10 @@
   "resolved" "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz"
   "version" "2.2.0"
 
-"pac-proxy-agent@^4.1.0":
-  "integrity" "sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q=="
-  "resolved" "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-4.1.0.tgz"
-  "version" "4.1.0"
+"pac-proxy-agent@^5.0.0":
+  "integrity" "sha512-CcFG3ZtnxO8McDigozwE3AqAw15zDvGH+OjXO4kzf7IkEKkQ4gxQ+3sdF50WmhQ4P/bVusXcqNE2S3XrNURwzQ=="
+  "resolved" "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-5.0.0.tgz"
+  "version" "5.0.0"
   dependencies:
     "@tootallnate/once" "1"
     "agent-base" "6"
@@ -1918,16 +1919,16 @@
     "get-uri" "3"
     "http-proxy-agent" "^4.0.1"
     "https-proxy-agent" "5"
-    "pac-resolver" "^4.1.0"
+    "pac-resolver" "^5.0.0"
     "raw-body" "^2.2.0"
     "socks-proxy-agent" "5"
 
-"pac-resolver@^4.1.0":
-  "integrity" "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ=="
-  "resolved" "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.2.0.tgz"
-  "version" "4.2.0"
+"pac-resolver@^5.0.0":
+  "integrity" "sha512-H+/A6KitiHNNW+bxBKREk2MCGSxljfqRX76NjummWEYIat7ldVXRU3dhRIE3iXZ0nvGBk6smv3nntxKkzRL8NA=="
+  "resolved" "https://registry.npmjs.org/pac-resolver/-/pac-resolver-5.0.0.tgz"
+  "version" "5.0.0"
   dependencies:
-    "degenerator" "^2.2.0"
+    "degenerator" "^3.0.1"
     "ip" "^1.1.5"
     "netmask" "^2.0.1"
 
@@ -2066,17 +2067,17 @@
     "object-assign" "^4.1.1"
     "react-is" "^16.8.1"
 
-"proxy-agent@^4.0.1":
-  "integrity" "sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA=="
-  "resolved" "https://registry.npmjs.org/proxy-agent/-/proxy-agent-4.0.1.tgz"
-  "version" "4.0.1"
+"proxy-agent@^5.0.0":
+  "integrity" "sha512-gkH7BkvLVkSfX9Dk27W6TyNOWWZWRilRfk1XxGNWOYJ2TuedAv1yFpCaU9QSBmBe716XOTNpYNOzhysyw8xn7g=="
+  "resolved" "https://registry.npmjs.org/proxy-agent/-/proxy-agent-5.0.0.tgz"
+  "version" "5.0.0"
   dependencies:
     "agent-base" "^6.0.0"
     "debug" "4"
     "http-proxy-agent" "^4.0.0"
     "https-proxy-agent" "^5.0.0"
     "lru-cache" "^5.1.1"
-    "pac-proxy-agent" "^4.1.0"
+    "pac-proxy-agent" "^5.0.0"
     "proxy-from-env" "^1.0.0"
     "socks-proxy-agent" "^5.0.0"
 
@@ -2343,9 +2344,9 @@
     "is-fullwidth-code-point" "^2.0.0"
 
 "smart-buffer@^4.1.0":
-  "integrity" "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
-  "resolved" "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz"
-  "version" "4.1.0"
+  "integrity" "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+  "resolved" "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz"
+  "version" "4.2.0"
 
 "socks-proxy-agent@^5.0.0", "socks-proxy-agent@5":
   "integrity" "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ=="
@@ -2631,9 +2632,9 @@
     "strip-bom" "^3.0.0"
 
 "tslib@^2.0.1":
-  "integrity" "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
-  "resolved" "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz"
-  "version" "2.3.0"
+  "integrity" "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+  "resolved" "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz"
+  "version" "2.3.1"
 
 "type-check@^0.4.0", "type-check@~0.4.0":
   "integrity" "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="
@@ -2726,6 +2727,11 @@
   dependencies:
     "spdx-correct" "^3.0.0"
     "spdx-expression-parse" "^3.0.0"
+
+"vm2@^3.9.3":
+  "integrity" "sha512-smLS+18RjXYMl9joyJxMNI9l4w7biW8ilSDaVRvFBDwOH8P0BK1ognFQTpg0wyQ6wIKLTblHJvROW692L/E53Q=="
+  "resolved" "https://registry.npmjs.org/vm2/-/vm2-3.9.3.tgz"
+  "version" "3.9.3"
 
 "which-boxed-primitive@^1.0.2":
   "integrity" "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg=="


### PR DESCRIPTION
updated proxy-agent to 5.0.0 to address vulnerability in proxy-agent 4.0.1 dependency

From npm audit report:

pac-resolver  <5.0.0
Severity: high
Code Injection - https://npmjs.com/advisories/1784
fix available via `npm audit fix --force`
Will install node-lambda@0.10.0, which is a breaking change
node_modules/pac-resolver
  pac-proxy-agent  <=4.1.0
  Depends on vulnerable versions of pac-resolver
  node_modules/pac-proxy-agent
    proxy-agent  1.1.0 - 4.0.1
    Depends on vulnerable versions of pac-proxy-agent
    node_modules/proxy-agent
      node-lambda  >=0.11.0
      Depends on vulnerable versions of proxy-agent
      node_modules/node-lambda
