### PR TITLE
feat(lib/main): separate `_npmInstall` method into `_getNpmInstallCommand` and `_packageInstall`

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -385,23 +385,33 @@ Emulate only the body of the API Gateway event.
     return fs.existsSync(path.join(codeDirectory, 'package-lock.json'))
   }
 
-  _npmInstall (program, codeDirectory) {
-    // Run on windows:
-    // https://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows
-
-    const installCommand = this._shouldUseNpmCi(codeDirectory)
-      ? 'ci'
-      : 'install'
-    const npmInstallBaseOptions = [
+  _getNpmInstallCommand (program, codeDirectory) {
+    const installOptions = [
       '-s',
-      installCommand,
+      this._shouldUseNpmCi(codeDirectory) ? 'ci' : 'install',
       '--production',
       '--no-audit'
     ]
 
     if (program.optionalDependencies === false) {
-      npmInstallBaseOptions.push('--no-optional')
+      installOptions.push('--no-optional')
     }
+
+    if (!program.dockerImage) {
+      installOptions.push('--prefix', codeDirectory)
+    }
+
+    return {
+      packageManager: 'npm',
+      installOptions
+    }
+  }
+
+  _packageInstall (program, codeDirectory) {
+    // Run on windows:
+    // https://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows
+
+    const { packageManager, installOptions } = this._getNpmInstallCommand(program, codeDirectory)
 
     const paramsOnContainer = (() => {
       // with docker
@@ -409,7 +419,7 @@ Emulate only the body of the API Gateway event.
       program.dockerVolumes && program.dockerVolumes.split(' ').forEach((volume) => {
         dockerVolumesOptions = dockerVolumesOptions.concat(['-v', volume])
       })
-      const dockerCommand = [program.dockerImage, 'npm'].concat(npmInstallBaseOptions)
+      const dockerCommand = [program.dockerImage, packageManager].concat(installOptions)
       const dockerBaseOptions = [
         'run', '--rm',
         '-v', `${fs.realpathSync(codeDirectory)}:/var/task`,
@@ -429,17 +439,16 @@ Emulate only the body of the API Gateway event.
     })()
 
     const paramsOnHost = (() => {
-      // simple npm install
-      const options = npmInstallBaseOptions.concat(['--prefix', codeDirectory])
+      // simple install
       if (process.platform === 'win32') {
         return {
           command: 'cmd.exe',
-          options: ['/c', 'npm'].concat(options)
+          options: ['/c', packageManager].concat(installOptions)
         }
       }
       return {
-        command: 'npm',
-        options
+        command: packageManager,
+        options: installOptions
       }
     })()
 
@@ -518,7 +527,7 @@ Emulate only the body of the API Gateway event.
 
   _codeDirectory () {
     // Why realpathSync?:
-    // If tmpdir is symbolic link and npm>=7, `this._npmInstall()` may not work properly.
+    // If tmpdir is symbolic link and npm>=7, `this._packageInstall()` may not work properly.
     return path.join(fs.realpathSync(os.tmpdir()), `${path.basename(path.resolve('.'))}-lambda`)
   }
 
@@ -691,8 +700,8 @@ they may not work as expected in the Lambda environment.
     console.log('=> Moving files to temporary directory')
     await this._fileCopy(program, lambdaSrcDirectory, codeDirectory, true)
     if (!program.keepNodeModules) {
-      console.log(`=> Running npm ${this._shouldUseNpmCi(codeDirectory) ? 'ci' : 'install'} --production`)
-      await this._npmInstall(program, codeDirectory)
+      console.log('=> Running package install')
+      await this._packageInstall(program, codeDirectory)
     }
     await this._postInstallScript(program, codeDirectory)
     console.log('=> Zipping deployment package')


### PR DESCRIPTION
Separate `_npmInstall` method into two parts.
* Get the command string (`_getNpmInstallCommand`)
* Execute the command (`_packageInstall`)

(Prepare for "Support for yarn #579".
I will be adding `_getYarnInstallCommand` method.)