### PR TITLE
fix: skip installing the package, when there is no `package.json`

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -429,6 +429,11 @@ Emulate only the body of the API Gateway event.
   }
 
   _packageInstall (program, codeDirectory) {
+    if (!fs.existsSync(path.join(codeDirectory, 'package.json'))) {
+      console.log('Skip the installation of the package. (Because package.json is not found.)')
+      return
+    }
+
     // Run on windows:
     // https://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows
 
@@ -729,7 +734,9 @@ they may not work as expected in the Lambda environment.
     if (!program.keepNodeModules) {
       console.log('=> Running package install')
       const usedPackageManager = await this._packageInstall(program, codeDirectory)
-      console.log(`(Package manager used was '${usedPackageManager}'.)`)
+      if (usedPackageManager) {
+        console.log(`(Package manager used was '${usedPackageManager}'.)`)
+      }
     }
     await this._postInstallScript(program, codeDirectory)
     console.log('=> Zipping deployment package')


### PR DESCRIPTION
https://github.com/motdotla/node-lambda/issues/537#issuecomment-1002781327