### PR TITLE
test: fix error with npm8

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -740,6 +740,9 @@ describe('lib/main', function () {
       const packageJson = require(packageJsonPath)
       packageJson.optionalDependencies = { npm: '*' }
       fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson))
+
+      // Remove package-lock.json because it does not match the package.json to which optionalDependencies was added.
+      fs.removeSync(path.join(codeDirectory, 'package-lock.json'))
     }
 
     const testOptionalDependenciesIsInstalled = async (packageManager) => {


### PR DESCRIPTION
```
packageJson.optionalDependencies = { npm: '*' }
```
The reason seems to be that the contents of 'package.json' and 'package-lock.json' do not match according to the above.

Removing 'package-lock.json' will not affect the validity of this test.