### PR TITLE
Improve CI settings

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,19 +3,37 @@ name: Node CI
 on: [push, pull_request]
 
 jobs:
-  test:
-    name: Test on node ${{ matrix.node-version }} and ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+  ubuntu-test:
+    name: Test on node ${{ matrix.node-version }} and Ubuntu
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         node-version: [12.x, 14.x, 16.x, 17.x]
-        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm i -g npm
+    - run: node -v
+    - run: npm -v
+    - run: npm ci
+    - run: npm test
+
+  mac-and-windows-test:
+    name: Test on node latest and ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 16.x
         cache: 'npm'
     - run: npm i -g npm
     - run: node -v

--- a/test/main.js
+++ b/test/main.js
@@ -133,8 +133,8 @@ const _awsRestore = () => {
 describe('lib/main', function () {
   if (['win32', 'darwin'].includes(process.platform)) {
     // It seems that it takes time for file operation in Windows and Mac.
-    // So set `timeout(60000)` for the whole test.
-    this.timeout(60000)
+    // So set `timeout(120000)` for the whole test.
+    this.timeout(120000)
   }
 
   let aws = null // mock


### PR DESCRIPTION
* Change mac and windows to only test nodejs@latest
    * One version is enough to test for each OS.
    * Testing for each version of nodejs is done only on Ubuntu.
* Extend the time as it often times out