### PR TITLE
bump to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -450,3 +450,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Support for Architectures parameter [#591](https://github.com/motdotla/node-lambda/pull/591)
 ### Bugfixes
 - fix: skip installing the package, when there is no `package.json` [#589](https://github.com/motdotla/node-lambda/pull/589)
+
+## [1.0.0] - 2022-05-19
+### Features
+- feat: remove BUILD from the exclusion list [#607](https://github.com/motdotla/node-lambda/pull/607)
+    - BREAKING CHANGES
+- add nodejs16.x to runtime [#605](https://github.com/motdotla/node-lambda/pull/605)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-lambda",
-  "version": "0.22.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-lambda",
-      "version": "0.22.0",
+      "version": "1.0.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "archiver": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lambda",
-  "version": "0.22.0",
+  "version": "1.0.0",
   "description": "Command line tool for locally running and remotely deploying your node.js applications to Amazon Lambda.",
   "main": "lib/main.js",
   "directories": {

--- a/test/main.js
+++ b/test/main.js
@@ -151,7 +151,7 @@ describe('lib/main', function () {
   })
 
   it('version should be set', () => {
-    assert.equal(lambda.version, '0.22.0')
+    assert.equal(lambda.version, '1.0.0')
   })
 
   describe('_codeDirectory', () => {


### PR DESCRIPTION
1.0.0 because the default exclusions change.