### PR TITLE
fix the bug in `excludeGlobs` in `_fileCopy`

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -364,7 +364,7 @@ Emulate only the body of the API Gateway event.
               return true
             }
 
-            if (!minimatch(src, pattern, { matchBase: true })) {
+            if (!minimatch(src, pattern, { matchBase: true, windowsPathsNoEscape: true })) {
               return true
             }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "dotenv": "^16.0.0",
         "fs-extra": "^10.0.0",
         "klaw": "^4.0.1",
-        "minimatch": "^5.0.0",
+        "minimatch": "^5.1.0",
         "proxy-agent": "^5.0.0"
       },
       "bin": {
@@ -3024,9 +3024,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.0.tgz",
-      "integrity": "sha512-EU+GCVjXD00yOUf1TwAHVP7v3fBD3A8RkkPYsWWKGWesxM/572sL53wJQnHxquHlRhYUV36wHkqrN8cdikKc2g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -6821,9 +6821,9 @@
       }
     },
     "minimatch": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.0.tgz",
-      "integrity": "sha512-EU+GCVjXD00yOUf1TwAHVP7v3fBD3A8RkkPYsWWKGWesxM/572sL53wJQnHxquHlRhYUV36wHkqrN8cdikKc2g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
       "requires": {
         "brace-expansion": "^2.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "dotenv": "^16.0.0",
     "fs-extra": "^10.0.0",
     "klaw": "^4.0.1",
-    "minimatch": "^5.0.0",
+    "minimatch": "^5.1.0",
     "proxy-agent": "^5.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1655,10 +1655,10 @@
   dependencies:
     "brace-expansion" "^1.1.7"
 
-"minimatch@^5.0.0":
-  "integrity" "sha512-EU+GCVjXD00yOUf1TwAHVP7v3fBD3A8RkkPYsWWKGWesxM/572sL53wJQnHxquHlRhYUV36wHkqrN8cdikKc2g=="
-  "resolved" "https://registry.npmjs.org/minimatch/-/minimatch-5.0.0.tgz"
-  "version" "5.0.0"
+"minimatch@^5.1.0":
+  "integrity" "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg=="
+  "resolved" "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz"
+  "version" "5.1.0"
   dependencies:
     "brace-expansion" "^2.0.1"
 


### PR DESCRIPTION
It was not working as expected partially in Windows.

Related :
https://github.com/isaacs/minimatch/commit/43cfa815a02f0344b7882b5b7471641c6943bf98