### PR TITLE
feat: drop nodejs12 from runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ AWS Lambda will let you set environment variables for your function. Use the sam
 
 ## Node.js Runtime Configuration
 
-AWS Lambda now supports Node.js 16, Node.js 14 and Node.js 12. Please also check the [Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) page.
+AWS Lambda now supports Node.js 16 and Node.js 14. Please also check the [Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) page.
 
 ## Use S3 to deploy
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -52,7 +52,7 @@ event_sources.json and ${program.eventFile} files as needed.`)
   }
 
   run (program) {
-    if (!['nodejs12.x', 'nodejs14.x', 'nodejs16.x'].includes(program.runtime)) {
+    if (!['nodejs14.x', 'nodejs16.x'].includes(program.runtime)) {
       console.error(`Runtime [${program.runtime}] is not supported.`)
       process.exit(254)
     }


### PR DESCRIPTION
To be deprecated soon.
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html