### PR TITLE
feat: support esm

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -51,7 +51,7 @@ Edit the .env, deploy.env, ${program.contextFile}, \
 event_sources.json and ${program.eventFile} files as needed.`)
   }
 
-  run (program) {
+  async run (program) {
     if (!['nodejs14.x', 'nodejs16.x'].includes(program.runtime)) {
       console.error(`Runtime [${program.runtime}] is not supported.`)
       process.exit(254)
@@ -67,7 +67,7 @@ event_sources.json and ${program.eventFile} files as needed.`)
       this._setRunTimeEnvironmentVars(program)
     }
 
-    const handler = require(path.join(process.cwd(), filename))[handlername]
+    const handler = (await import(path.join(process.cwd(), filename)))[handlername]
     const event = require(path.join(process.cwd(), program.eventFile))
     const context = require(path.join(process.cwd(), program.contextFile))
     const enableRunMultipleEvents = (() => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -67,7 +67,18 @@ event_sources.json and ${program.eventFile} files as needed.`)
       this._setRunTimeEnvironmentVars(program)
     }
 
-    const handler = (await import(path.join(process.cwd(), filename)))[handlername]
+    const handlerFilePath = (() => {
+      const filePath = path.join(process.cwd(), filename)
+      if (path.sep === '\\') {
+        // Convert because of error in Windows.
+        // Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]:
+        // Only URLs with a scheme in: file, data are supported by the default ESM loader.
+        // On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
+        return 'file:///' + filePath.split(path.sep).join('/')
+      }
+      return filePath
+    })()
+    const handler = (await import(handlerFilePath))[handlername]
     const event = require(path.join(process.cwd(), program.eventFile))
     const context = require(path.join(process.cwd(), program.contextFile))
     const enableRunMultipleEvents = (() => {


### PR DESCRIPTION
CommonJS and ES Modules could be imported using `import()`.

fix #612