### PR TITLE
Add support for nodejs18x runtime

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -52,7 +52,7 @@ event_sources.json and ${program.eventFile} files as needed.`)
   }
 
   async run (program) {
-    if (!['nodejs14.x', 'nodejs16.x'].includes(program.runtime)) {
+    if (!['nodejs14.x', 'nodejs16.x', 'nodejs18.x'].includes(program.runtime)) {
       console.error(`Runtime [${program.runtime}] is not supported.`)
       process.exit(254)
     }

--- a/test/node-lambda.js
+++ b/test/node-lambda.js
@@ -171,6 +171,27 @@ describe('bin/node-lambda', () => {
       })
     })
 
+    describe('node-lambda run (Runtime nodejs18.x is supported)', () => {
+      const eventObj = {
+        asyncTest: false,
+        callbackWaitsForEmptyEventLoop: true // True is the default value of Lambda
+      }
+
+      before(() => {
+        process.env.AWS_RUNTIME = 'nodejs18.x'
+      })
+      after(() => {
+        process.env.AWS_RUNTIME = 'nodejs16.x'
+      })
+
+      it('`node-lambda run` exitCode is not `254` (callback(null))', (done) => {
+        _generateEventFile(Object.assign(eventObj, {
+          callbackCode: 'callback(null);'
+        }))
+        _testMain({ stdoutRegExp: /Success:$/, exitCode: 0 }, done)
+      })
+    })
+
     describe('node-lambda run (Multiple events))', () => {
       const eventObj = [{
         asyncTest: false,


### PR DESCRIPTION
**description:** node-lambda run gives an error if `AWS_RUNTIME=nodejs18.x`

[AWS now supports nodejs18.x runtime.](https://aws.amazon.com/blogs/compute/node-js-18-x-runtime-now-available-in-aws-lambda/)

**fixes:**
- add `nodejs18.x` to the if statement at `main.js`

