### PR TITLE
ci: use npm already installed

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,7 +16,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm i -g npm
     - run: node -v
     - run: npm -v
     - run: npm ci
@@ -35,7 +34,6 @@ jobs:
       with:
         node-version: 20.x
         cache: 'npm'
-    - run: npm i -g npm
     - run: node -v
     - run: npm -v
     - run: npm ci


### PR DESCRIPTION
The latest npm may not support the version of Node.js used in CI.

https://github.com/motdotla/node-lambda/actions/runs/7012000032/job/19075659717?pr=696