### PR TITLE
Drop Node.js 16.x from CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "author": "motdotla",
   "license": "BSD-2-Clause",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 18.0.0"
   },
   "dependencies": {
     "archiver": "^6.0.0",


### PR DESCRIPTION
Node.js 16.x is EOL.
https://github.com/nodejs/Release