### PR TITLE
sdk-v3: Remove v2 lambda client

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -971,22 +971,17 @@ they may not work as expected in the Lambda environment.
     }
     console.log(params)
 
-    // Migrating to v3.
-    const lambda = new aws.sdk.Lambda({
-      region,
-      apiVersion: '2015-03-31'
-    })
     const lambdaClient = new LambdaClient({ region })
-
+    // Migrating to v3.
     const scheduleEvents = new ScheduleEvents(aws.sdk, region)
     const s3Events = new S3Events(aws.sdk, region)
     const cloudWatchLogs = new CloudWatchLogs(aws.sdk, region)
 
     const existsFunction = await (async () => {
       try {
-        await lambda.getFunction({
+        await lambdaClient.send(new GetFunctionCommand({
           FunctionName: params.FunctionName
-        }).promise()
+        }))
         return true
       } catch (err) {
         if (!this._isFunctionDoesNotExist(err)) {


### PR DESCRIPTION
GH-641

All lambda clients have been replaced by v3.
The next step is to replace other AWS resources with v3 as well.