### PR TITLE
Bump version 2.0.0-alpha.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-lambda",
-  "version": "1.3.0",
+  "version": "2.0.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-lambda",
-      "version": "1.3.0",
+      "version": "2.0.0-alpha.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-events": "^3.797.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lambda",
-  "version": "1.3.0",
+  "version": "2.0.0-alpha.0",
   "description": "Command line tool for locally running and remotely deploying your node.js applications to Amazon Lambda.",
   "main": "lib/main.js",
   "directories": {

--- a/test/main.js
+++ b/test/main.js
@@ -192,7 +192,7 @@ describe('lib/main', function () {
   })
 
   it('version should be set', () => {
-    assert.equal(lambda.version, '1.3.0')
+    assert.equal(lambda.version, '2.0.0-alpha.0')
   })
 
   describe('_codeDirectory', () => {


### PR DESCRIPTION
GH-641

We haven't migrated all the features from SDK v2, but we've migrated the minimum required features to SDK v3, so we're releasing it.

Publish using the following command:

```
npm publish --tag next
```